### PR TITLE
Update Logic.cs // Change KeepMinCP Part II

### DIFF
--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -415,9 +415,6 @@ namespace PokemonGo.RocketAPI.Logic
 
             foreach (var duplicatePokemon in duplicatePokemons)
             {
-                if (PokemonInfo.CalculatePokemonPerfection(duplicatePokemon) >= _clientSettings.KeepMinIVPercentage || duplicatePokemon.Cp > _clientSettings.KeepMinCP)
-                    continue;
-
                 var transfer = await _client.TransferPokemon(duplicatePokemon.Id);
                 _stats.IncreasePokemonsTransfered();
                 _stats.UpdateConsoleTitle(_inventory);


### PR DESCRIPTION
KeepMinCP can be found not in the Inventory.cs Query.

Checking for KeepMinIVPercentage is bad, because it keeps CP 10 Pokemons when they have a MinIV

Will search for a better KeepMinIVPercentage later..