### PR TITLE
Update Statistics.cs // removed decimal numbers for EXP/H and P/H

### DIFF
--- a/PokemonGo.RocketAPI.Logic/Utils/Statistics.cs
+++ b/PokemonGo.RocketAPI.Logic/Utils/Statistics.cs
@@ -171,7 +171,7 @@ namespace PokemonGo.RocketAPI.Logic.Utils
         {
             return
                 string.Format(
-                    "{0} - Runtime {1} - Lvl: {2:0} | EXP/H: {3:0.0} | P/H: {4:0.0} | Stardust: {5:0} | Transfered: {6:0} | Items Recycled: {7:0}",
+                    "{0} - Runtime {1} - Lvl: {2:0} | EXP/H: {3:0} | P/H: {4:0} | Stardust: {5:0} | Transfered: {6:0} | Items Recycled: {7:0}",
                     PlayerName, _getSessionRuntimeInTimeFormat(), CurrentLevelInfos, TotalExperience/_getSessionRuntime(),
                     TotalPokemons/_getSessionRuntime(), TotalStardust, TotalPokemonsTransfered, TotalItemsRemoved);
         }


### PR DESCRIPTION
We dont need decimal numbers for EXP/H and P/H.
Or can we catch a half pokemon? O.o