### PR TITLE
Fix loading Item Counts

### DIFF
--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -114,7 +114,7 @@ namespace PokemonGo.RocketAPI.Console
                     string[] itemInfoArray = itemInfo.Split(' ');
                     string itemName = itemInfoArray.Length > 1 ? itemInfoArray[0] : "";
                     int itemAmount = 0;
-                    if (Int32.TryParse(itemInfoArray.Length > 1 ? itemInfoArray[1] : "100", out itemAmount)) itemAmount = 100;
+                    if (!Int32.TryParse(itemInfoArray.Length > 1 ? itemInfoArray[1] : "100", out itemAmount)) itemAmount = 100;
 
                     ItemId item;
                     if (Enum.TryParse<ItemId>(itemName, out item))


### PR DESCRIPTION
It was setting the item amounts all to 100 because of a logic typo.

If it successfully parsed the amount, it would put it in itemAmount and return true, thus overwriting the parsed amount with 100.