### PR TITLE
KeepMinDuplicatePokemon can now be set to zero

### DIFF
--- a/PokemonGo.RocketAPI.Logic/Inventory.cs
+++ b/PokemonGo.RocketAPI.Logic/Inventory.cs
@@ -115,7 +115,7 @@ namespace PokemonGo.RocketAPI.Logic
             {
                 return pokemonList
                     .GroupBy(p => p.PokemonId)
-                    .Where(x => x.Count() > 1)
+                    .Where(x => x.Count() > _client.Settings.KeepMinDuplicatePokemon)
                     .SelectMany(
                         p =>
                             p.OrderByDescending(PokemonInfo.CalculatePokemonPerfection)
@@ -125,7 +125,7 @@ namespace PokemonGo.RocketAPI.Logic
             }
             return pokemonList
                 .GroupBy(p => p.PokemonId)
-                .Where(x => x.Count() > 1)
+                .Where(x => x.Count() > _client.Settings.KeepMinDuplicatePokemon)
                 .SelectMany(
                     p =>
                         p.OrderByDescending(x => x.Cp)

--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -708,6 +708,8 @@ namespace PokemonGo.RocketAPI.Logic
                 var bestPokemonOfType = _client.Settings.PrioritizeIVOverCP
                     ? await _inventory.GetHighestPokemonOfTypeByIv(duplicatePokemon)
                     : await _inventory.GetHighestPokemonOfTypeByCp(duplicatePokemon);
+                if (bestPokemonOfType == null)
+                    bestPokemonOfType = duplicatePokemon;
                 Logger.Write(
                     $"{duplicatePokemon.PokemonId} with {duplicatePokemon.Cp} ({PokemonInfo.CalculatePokemonPerfection(duplicatePokemon).ToString("0.00")} % perfect) CP (Best: {bestPokemonOfType.Cp} | ({PokemonInfo.CalculatePokemonPerfection(bestPokemonOfType).ToString("0.00")} % perfect))",
                     LogLevel.Transfer);


### PR DESCRIPTION
Made it possible to transfer Pokemon when you have only one of this type left.
Fixes an error when you wanted to transfer your best Pokemon(last one).

(In case you only want Pokemons reaching your criterion)