### PR TITLE
Fix recycling

### DIFF
--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -114,7 +114,7 @@ namespace PokemonGo.RocketAPI.Console
                     string[] itemInfoArray = itemInfo.Split(' ');
                     string itemName = itemInfoArray.Length > 1 ? itemInfoArray[0] : "";
                     int itemAmount = 0;
-                    if (Int32.TryParse(itemInfoArray.Length > 1 ? itemInfoArray[1] : "100", out itemAmount)) itemAmount = 100;
+                    if (!Int32.TryParse(itemInfoArray.Length > 1 ? itemInfoArray[1] : "100", out itemAmount)) itemAmount = 100;
 
                     ItemId item;
                     if (Enum.TryParse<ItemId>(itemName, out item))


### PR DESCRIPTION
I know this should go to develop, but this is kinda a showstopper bug.

If the TryParse succeeds, it puts the value into itemAmount and returns true. If it returns true, it catches the If and so puts the itemAmount to 100. This can cause your inventory to get full and you can't recycle.