### PR TITLE
Fixed a logic error in GetDuplicatePokemonToTransfer & reduced size of GetXpDiff

### DIFF
--- a/PokemonGo.RocketAPI.Console/App.config
+++ b/PokemonGo.RocketAPI.Console/App.config
@@ -55,6 +55,9 @@
       <setting name="EvolveAllPokemonWithEnoughCandy" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="KeepPokemonsThatCanEvolve" serializeAs="String">
+        <value>False</value>
+      </setting>
       <setting name="TransferDuplicatePokemon" serializeAs="String">
         <value>True</value>
       </setting>

--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -28,6 +28,7 @@ namespace PokemonGo.RocketAPI.Console
         public int KeepMinCP => UserSettings.Default.KeepMinCP;
         public double WalkingSpeedInKilometerPerHour => UserSettings.Default.WalkingSpeedInKilometerPerHour;
         public bool EvolveAllPokemonWithEnoughCandy => UserSettings.Default.EvolveAllPokemonWithEnoughCandy;
+        public bool KeepPokemonsThatCanEvolve => UserSettings.Default.KeepPokemonsThatCanEvolve;
         public bool TransferDuplicatePokemon => UserSettings.Default.TransferDuplicatePokemon;
         public int DelayBetweenPokemonCatch => UserSettings.Default.DelayBetweenPokemonCatch;
         public bool UsePokemonToNotCatchFilter => UserSettings.Default.UsePokemonToNotCatchFilter;

--- a/PokemonGo.RocketAPI.Console/UserSettings.Designer.cs
+++ b/PokemonGo.RocketAPI.Console/UserSettings.Designer.cs
@@ -145,6 +145,18 @@ namespace PokemonGo.RocketAPI.Console {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool KeepPokemonsThatCanEvolve {
+            get {
+                return ((bool)(this["KeepPokemonsThatCanEvolve"]));
+            }
+            set {
+                this["KeepPokemonsThatCanEvolve"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]
         public bool TransferDuplicatePokemon {
             get {

--- a/PokemonGo.RocketAPI.Console/UserSettings.settings
+++ b/PokemonGo.RocketAPI.Console/UserSettings.settings
@@ -32,6 +32,9 @@
     <Setting Name="EvolveAllPokemonWithEnoughCandy" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="KeepPokemonsThatCanEvolve" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="TransferDuplicatePokemon" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>

--- a/PokemonGo.RocketAPI.Logic/Inventory.cs
+++ b/PokemonGo.RocketAPI.Logic/Inventory.cs
@@ -84,13 +84,11 @@ namespace PokemonGo.RocketAPI.Logic
                 {
                     var settings = pokemonSettings.Single(x => x.PokemonId == pokemon.Key);
                     var familyCandy = pokemonFamilies.Single(x => settings.FamilyId == x.FamilyId);
-                    if (settings.CandyToEvolve == 0)
-                        continue;
+                    var amountToSkip = _client.Settings.KeepMinDuplicatePokemon;
 
-                    var amountToSkip = familyCandy.Candy/settings.CandyToEvolve;
-                    amountToSkip = amountToSkip > _client.Settings.KeepMinDuplicatePokemon
-                        ? amountToSkip
-                        : _client.Settings.KeepMinDuplicatePokemon;
+                    if (settings.CandyToEvolve > 0 && familyCandy.Candy / settings.CandyToEvolve > amountToSkip)
+                        amountToSkip = familyCandy.Candy / settings.CandyToEvolve;
+                    
                     if (prioritizeIVoverCp)
                     {
                         results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key)

--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -529,89 +529,15 @@ namespace PokemonGo.RocketAPI.Logic
 
         public static int GetXpDiff(int level)
         {
-            switch (level)
+            if(level > 0 && level <= 40 )
             {
-                case 1:
-                    return 0;
-                case 2:
-                    return 1000;
-                case 3:
-                    return 2000;
-                case 4:
-                    return 3000;
-                case 5:
-                    return 4000;
-                case 6:
-                    return 5000;
-                case 7:
-                    return 6000;
-                case 8:
-                    return 7000;
-                case 9:
-                    return 8000;
-                case 10:
-                    return 9000;
-                case 11:
-                    return 10000;
-                case 12:
-                    return 10000;
-                case 13:
-                    return 10000;
-                case 14:
-                    return 10000;
-                case 15:
-                    return 15000;
-                case 16:
-                    return 20000;
-                case 17:
-                    return 20000;
-                case 18:
-                    return 20000;
-                case 19:
-                    return 25000;
-                case 20:
-                    return 25000;
-                case 21:
-                    return 50000;
-                case 22:
-                    return 75000;
-                case 23:
-                    return 100000;
-                case 24:
-                    return 125000;
-                case 25:
-                    return 150000;
-                case 26:
-                    return 190000;
-                case 27:
-                    return 200000;
-                case 28:
-                    return 250000;
-                case 29:
-                    return 300000;
-                case 30:
-                    return 350000;
-                case 31:
-                    return 500000;
-                case 32:
-                    return 500000;
-                case 33:
-                    return 750000;
-                case 34:
-                    return 1000000;
-                case 35:
-                    return 1250000;
-                case 36:
-                    return 1500000;
-                case 37:
-                    return 2000000;
-                case 38:
-                    return 2500000;
-                case 39:
-                    return 1000000;
-                case 40:
-                    return 1000000;
+                int[] xpTable = { 0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000,
+                    10000, 10000, 10000, 10000, 15000, 20000, 20000, 20000, 25000, 25000,
+                    50000, 75000, 100000, 125000, 150000, 190000, 200000, 250000, 300000, 350000,
+                    500000, 500000, 750000, 1000000, 1250000, 1500000, 2000000, 2500000, 1000000, 1000000};
+                return xpTable[level-1];
             }
+            
             return 0;
         }
 

--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -615,11 +615,11 @@ namespace PokemonGo.RocketAPI.Logic
                 await action();
         }
 
-        private async Task TransferDuplicatePokemon(bool keepPokemonsThatCanEvolve = false)
+        private async Task TransferDuplicatePokemon()
         {
             var duplicatePokemons =
                 await
-                    _inventory.GetDuplicatePokemonToTransfer(keepPokemonsThatCanEvolve,
+                    _inventory.GetDuplicatePokemonToTransfer(_clientSettings.KeepPokemonsThatCanEvolve,
                         _clientSettings.PrioritizeIVOverCP, _clientSettings.PokemonsNotToTransfer);
 
             foreach (var duplicatePokemon in duplicatePokemons)

--- a/PokemonGo.RocketAPI/ISettings.cs
+++ b/PokemonGo.RocketAPI/ISettings.cs
@@ -20,6 +20,7 @@ namespace PokemonGo.RocketAPI
         int KeepMinCP { get; }
         double WalkingSpeedInKilometerPerHour { get; }
         bool EvolveAllPokemonWithEnoughCandy { get; }
+        bool KeepPokemonsThatCanEvolve { get; }
         bool TransferDuplicatePokemon { get; }
         int DelayBetweenPokemonCatch { get; }
         bool UsePokemonToNotCatchFilter { get; }


### PR DESCRIPTION
With KeepPokemonsThatCanEvolve=true it also kept all pokemons that couldn't evolve. Added KeepPokemonsThatCanEvolve to Settings