### PR TITLE
Fix: Decrement cached berry inventory count when using a berry

### DIFF
--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -725,6 +725,7 @@ namespace PokemonGo.RocketAPI.Logic
                 return;
 
             await _client.UseCaptureItem(encounterId, ItemId.ItemRazzBerry, spawnPointId);
+            berry.Count--;
             Logger.Write($"Used, remaining: {berry.Count}", LogLevel.Berry);
             await Task.Delay(3000);
         }


### PR DESCRIPTION
When using a berry the cached inventory was not being updated with the new decremented value. 