### PR TITLE
Recycle pokeballs, potions, revives and berries based on total count

### DIFF
--- a/PokemonGo.RocketAPI.Console/App.config
+++ b/PokemonGo.RocketAPI.Console/App.config
@@ -88,6 +88,18 @@
       <setting name="EvolveAboveIVValue" serializeAs="String">
         <value>95</value>
       </setting>
+      <setting name="MaxPokeBalls" serializeAs="String">
+        <value>100</value>
+      </setting>
+      <setting name="MaxPotions" serializeAs="String">
+        <value>25</value>
+      </setting>
+      <setting name="MaxBerries" serializeAs="String">
+        <value>50</value>
+      </setting>
+      <setting name="MaxRevives" serializeAs="String">
+        <value>25</value>
+      </setting>
     </PokemonGo.RocketAPI.Console.UserSettings>
   </userSettings>
 </configuration>

--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -41,6 +41,7 @@ namespace PokemonGo.RocketAPI.Console
         public float EvolveAboveIVValue => UserSettings.Default.EvolveAboveIVValue;
         public int MaxPokeBalls => 100;
         public int MaxPotions => 25;
+        public int MaxBerries => 50;
 
         //Type and amount to keep
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter
@@ -62,11 +63,6 @@ namespace PokemonGo.RocketAPI.Console
             new KeyValuePair<ItemId, int>(ItemId.ItemXAttack, 100),
             new KeyValuePair<ItemId, int>(ItemId.ItemXDefense, 100),
             new KeyValuePair<ItemId, int>(ItemId.ItemXMiracle, 100),
-            new KeyValuePair<ItemId, int>(ItemId.ItemRazzBerry, 50),
-            new KeyValuePair<ItemId, int>(ItemId.ItemBlukBerry, 10),
-            new KeyValuePair<ItemId, int>(ItemId.ItemNanabBerry, 10),
-            new KeyValuePair<ItemId, int>(ItemId.ItemWeparBerry, 30),
-            new KeyValuePair<ItemId, int>(ItemId.ItemPinapBerry, 30),
             new KeyValuePair<ItemId, int>(ItemId.ItemSpecialCamera, 100),
             new KeyValuePair<ItemId, int>(ItemId.ItemIncubatorBasicUnlimited, 100),
             new KeyValuePair<ItemId, int>(ItemId.ItemIncubatorBasic, 100),

--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -39,10 +39,10 @@ namespace PokemonGo.RocketAPI.Console
         public bool useLuckyEggsWhileEvolving => UserSettings.Default.useLuckyEggsWhileEvolving;
         public bool EvolveAllPokemonAboveIV => UserSettings.Default.EvolveAllPokemonAboveIV;
         public float EvolveAboveIVValue => UserSettings.Default.EvolveAboveIVValue;
-        public int MaxPokeBalls => 100;
-        public int MaxPotions => 25;
-        public int MaxBerries => 50;
-        public int MaxRevives => 25;
+        public int MaxPokeBalls => UserSettings.Default.MaxPokeBalls;
+        public int MaxPotions => UserSettings.Default.MaxPotions;
+        public int MaxBerries => UserSettings.Default.MaxBerries;
+        public int MaxRevives => UserSettings.Default.MaxRevives;
 
         //Type and amount to keep
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter

--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -39,6 +39,7 @@ namespace PokemonGo.RocketAPI.Console
         public bool useLuckyEggsWhileEvolving => UserSettings.Default.useLuckyEggsWhileEvolving;
         public bool EvolveAllPokemonAboveIV => UserSettings.Default.EvolveAllPokemonAboveIV;
         public float EvolveAboveIVValue => UserSettings.Default.EvolveAboveIVValue;
+        public int MaxPokeBalls => 100;
 
         //Type and amount to keep
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter
@@ -49,10 +50,6 @@ namespace PokemonGo.RocketAPI.Console
                 //Type of pokemons to evolve
                 var defaultItems = new List<KeyValuePair<ItemId, int>> {
                     new KeyValuePair<ItemId, int>(ItemId.ItemUnknown, 0),
-            new KeyValuePair<ItemId, int>(ItemId.ItemPokeBall, 25),
-            new KeyValuePair<ItemId, int>(ItemId.ItemGreatBall, 50),
-            new KeyValuePair<ItemId, int>(ItemId.ItemUltraBall, 75),
-            new KeyValuePair<ItemId, int>(ItemId.ItemMasterBall, 100),
             new KeyValuePair<ItemId, int>(ItemId.ItemPotion, 0),
             new KeyValuePair<ItemId, int>(ItemId.ItemSuperPotion, 25),
             new KeyValuePair<ItemId, int>(ItemId.ItemHyperPotion, 50),

--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -40,6 +40,7 @@ namespace PokemonGo.RocketAPI.Console
         public bool EvolveAllPokemonAboveIV => UserSettings.Default.EvolveAllPokemonAboveIV;
         public float EvolveAboveIVValue => UserSettings.Default.EvolveAboveIVValue;
         public int MaxPokeBalls => 100;
+        public int MaxPotions => 25;
 
         //Type and amount to keep
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter
@@ -50,10 +51,6 @@ namespace PokemonGo.RocketAPI.Console
                 //Type of pokemons to evolve
                 var defaultItems = new List<KeyValuePair<ItemId, int>> {
                     new KeyValuePair<ItemId, int>(ItemId.ItemUnknown, 0),
-            new KeyValuePair<ItemId, int>(ItemId.ItemPotion, 0),
-            new KeyValuePair<ItemId, int>(ItemId.ItemSuperPotion, 25),
-            new KeyValuePair<ItemId, int>(ItemId.ItemHyperPotion, 50),
-            new KeyValuePair<ItemId, int>(ItemId.ItemMaxPotion, 75),
             new KeyValuePair<ItemId, int>(ItemId.ItemRevive, 25),
             new KeyValuePair<ItemId, int>(ItemId.ItemMaxRevive, 50),
             new KeyValuePair<ItemId, int>(ItemId.ItemLuckyEgg, 200),

--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -42,6 +42,7 @@ namespace PokemonGo.RocketAPI.Console
         public int MaxPokeBalls => 100;
         public int MaxPotions => 25;
         public int MaxBerries => 50;
+        public int MaxRevives => 25;
 
         //Type and amount to keep
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter
@@ -52,8 +53,6 @@ namespace PokemonGo.RocketAPI.Console
                 //Type of pokemons to evolve
                 var defaultItems = new List<KeyValuePair<ItemId, int>> {
                     new KeyValuePair<ItemId, int>(ItemId.ItemUnknown, 0),
-            new KeyValuePair<ItemId, int>(ItemId.ItemRevive, 25),
-            new KeyValuePair<ItemId, int>(ItemId.ItemMaxRevive, 50),
             new KeyValuePair<ItemId, int>(ItemId.ItemLuckyEgg, 200),
             new KeyValuePair<ItemId, int>(ItemId.ItemIncenseOrdinary, 100),
             new KeyValuePair<ItemId, int>(ItemId.ItemIncenseSpicy, 100),

--- a/PokemonGo.RocketAPI.Console/UserSettings.Designer.cs
+++ b/PokemonGo.RocketAPI.Console/UserSettings.Designer.cs
@@ -274,5 +274,53 @@ namespace PokemonGo.RocketAPI.Console {
                 this["EvolveAboveIVValue"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("100")]
+        public int MaxPokeBalls {
+            get {
+                return ((int)(this["MaxPokeBalls"]));
+            }
+            set {
+                this["MaxPokeBalls"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("25")]
+        public int MaxPotions {
+            get {
+                return ((int)(this["MaxPotions"]));
+            }
+            set {
+                this["MaxPotions"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("50")]
+        public int MaxBerries {
+            get {
+                return ((int)(this["MaxBerries"]));
+            }
+            set {
+                this["MaxBerries"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("25")]
+        public int MaxRevives {
+            get {
+                return ((int)(this["MaxRevives"]));
+            }
+            set {
+                this["MaxRevives"] = value;
+            }
+        }
     }
 }

--- a/PokemonGo.RocketAPI.Console/UserSettings.settings
+++ b/PokemonGo.RocketAPI.Console/UserSettings.settings
@@ -65,5 +65,17 @@
     <Setting Name="EvolveAboveIVValue" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">95</Value>
     </Setting>
+    <Setting Name="MaxPokeBalls" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">100</Value>
+    </Setting>
+    <Setting Name="MaxPotions" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">25</Value>
+    </Setting>
+    <Setting Name="MaxBerries" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">50</Value>
+    </Setting>
+    <Setting Name="MaxRevives" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">25</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/PokemonGo.RocketAPI.Logic/Inventory.cs
+++ b/PokemonGo.RocketAPI.Logic/Inventory.cs
@@ -43,6 +43,12 @@ namespace PokemonGo.RocketAPI.Logic
             ItemId.ItemPinapBerry
         };
 
+        private readonly ItemId[] ReviveTypes = new[]
+        {
+            ItemId.ItemRevive,
+            ItemId.ItemMaxRevive
+        };
+
         public Inventory(Client client)
         {
             _client = client;
@@ -211,6 +217,7 @@ namespace PokemonGo.RocketAPI.Logic
             var balls = GetGroupedItemsToRecycle(PokeBallTypes, myItems, settings.MaxPokeBalls);
             var potions = GetGroupedItemsToRecycle(PotionTypes, myItems, settings.MaxPotions);
             var berries = GetGroupedItemsToRecycle(BerryTypes, myItems, settings.MaxBerries);
+            var revives = GetGroupedItemsToRecycle(ReviveTypes, myItems, settings.MaxRevives);
             var other = myItems
                 .Where(x => settings.ItemRecycleFilter.Any(f => f.Key == (ItemId)x.Item_ && x.Count > f.Value))
                 .Select(x =>
@@ -220,7 +227,7 @@ namespace PokemonGo.RocketAPI.Logic
                             Count = x.Count - settings.ItemRecycleFilter.Single(f => f.Key == (ItemId)x.Item_).Value,
                             Unseen = x.Unseen
                         });
-            return other.Concat(balls).Concat(potions).Concat(berries);
+            return other.Concat(balls).Concat(potions).Concat(berries).Concat(revives);
         }
 
         private IEnumerable<Item> GetGroupedItemsToRecycle(ItemId[] groupItemTypes, IEnumerable<Item> allItems, int maxItems)

--- a/PokemonGo.RocketAPI.Logic/Inventory.cs
+++ b/PokemonGo.RocketAPI.Logic/Inventory.cs
@@ -206,7 +206,7 @@ namespace PokemonGo.RocketAPI.Logic
 
         private IEnumerable<Item> GetGroupedItemsToRecycle(ItemId[] groupItemTypes, IEnumerable<Item> allItems, int maxItems)
         {
-            var groupedItems = allItems.Where(i => groupItemTypes.Contains((ItemId)i.Item_)).OrderBy(i => (MiscEnums.Item)i.Item_);
+            var groupedItems = allItems.Where(i => groupItemTypes.Contains((ItemId)i.Item_)).OrderBy(i => (ItemId)i.Item_);
             int count = groupedItems.Sum(b => b.Count);
 
             var toRecycle = new List<Item>();

--- a/PokemonGo.RocketAPI.Logic/Inventory.cs
+++ b/PokemonGo.RocketAPI.Logic/Inventory.cs
@@ -241,6 +241,9 @@ namespace PokemonGo.RocketAPI.Logic
                 if (count <= maxItems)
                     break;
 
+                if (currentType.Count == 0)
+                    continue;
+
                 int reduction = Math.Min(count - maxItems, currentType.Count);
                 count -= reduction;
                 toRecycle.Add(new Item { Item_ = currentType.Item_, Count = reduction, Unseen = currentType.Unseen });

--- a/PokemonGo.RocketAPI.Logic/Inventory.cs
+++ b/PokemonGo.RocketAPI.Logic/Inventory.cs
@@ -18,11 +18,20 @@ namespace PokemonGo.RocketAPI.Logic
         private GetInventoryResponse _cachedInventory;
         private DateTime _lastRefresh;
 
-        private readonly ItemId[] PokeBallTypes = new[] {
+        private readonly ItemId[] PokeBallTypes = new[] 
+        {
             ItemId.ItemPokeBall,
             ItemId.ItemGreatBall,
             ItemId.ItemUltraBall,
             ItemId.ItemMasterBall
+        };
+
+        private readonly ItemId[] PotionTypes = new[]
+        {
+            ItemId.ItemPotion,
+            ItemId.ItemSuperPotion,
+            ItemId.ItemHyperPotion,
+            ItemId.ItemMaxPotion
         };
 
         public Inventory(Client client)
@@ -191,17 +200,17 @@ namespace PokemonGo.RocketAPI.Logic
         {
             var myItems = await GetItems();
             var balls = GetGroupedItemsToRecycle(PokeBallTypes, myItems, settings.MaxPokeBalls);
-
-            return myItems
-                .Where(x => settings.ItemRecycleFilter.Any(f => f.Key == (ItemId) x.Item_ && x.Count > f.Value))
-                .Select(
-                    x =>
+            var potions = GetGroupedItemsToRecycle(PotionTypes, myItems, settings.MaxPotions);
+            var other = myItems
+                .Where(x => settings.ItemRecycleFilter.Any(f => f.Key == (ItemId)x.Item_ && x.Count > f.Value))
+                .Select(x =>
                         new Item
                         {
                             Item_ = x.Item_,
-                            Count = x.Count - settings.ItemRecycleFilter.Single(f => f.Key == (ItemId) x.Item_).Value,
+                            Count = x.Count - settings.ItemRecycleFilter.Single(f => f.Key == (ItemId)x.Item_).Value,
                             Unseen = x.Unseen
-                        }).Concat(balls);
+                        });
+            return other.Concat(balls).Concat(potions);
         }
 
         private IEnumerable<Item> GetGroupedItemsToRecycle(ItemId[] groupItemTypes, IEnumerable<Item> allItems, int maxItems)

--- a/PokemonGo.RocketAPI.Logic/Inventory.cs
+++ b/PokemonGo.RocketAPI.Logic/Inventory.cs
@@ -34,6 +34,15 @@ namespace PokemonGo.RocketAPI.Logic
             ItemId.ItemMaxPotion
         };
 
+        private readonly ItemId[] BerryTypes = new[]
+        {
+            ItemId.ItemRazzBerry,
+            ItemId.ItemBlukBerry,
+            ItemId.ItemNanabBerry,
+            ItemId.ItemWeparBerry,
+            ItemId.ItemPinapBerry
+        };
+
         public Inventory(Client client)
         {
             _client = client;
@@ -201,6 +210,7 @@ namespace PokemonGo.RocketAPI.Logic
             var myItems = await GetItems();
             var balls = GetGroupedItemsToRecycle(PokeBallTypes, myItems, settings.MaxPokeBalls);
             var potions = GetGroupedItemsToRecycle(PotionTypes, myItems, settings.MaxPotions);
+            var berries = GetGroupedItemsToRecycle(BerryTypes, myItems, settings.MaxBerries);
             var other = myItems
                 .Where(x => settings.ItemRecycleFilter.Any(f => f.Key == (ItemId)x.Item_ && x.Count > f.Value))
                 .Select(x =>
@@ -210,7 +220,7 @@ namespace PokemonGo.RocketAPI.Logic
                             Count = x.Count - settings.ItemRecycleFilter.Single(f => f.Key == (ItemId)x.Item_).Value,
                             Unseen = x.Unseen
                         });
-            return other.Concat(balls).Concat(potions);
+            return other.Concat(balls).Concat(potions).Concat(berries);
         }
 
         private IEnumerable<Item> GetGroupedItemsToRecycle(ItemId[] groupItemTypes, IEnumerable<Item> allItems, int maxItems)

--- a/PokemonGo.RocketAPI/ISettings.cs
+++ b/PokemonGo.RocketAPI/ISettings.cs
@@ -33,6 +33,7 @@ namespace PokemonGo.RocketAPI
         float EvolveAboveIVValue { get; }
         int MaxPokeBalls { get; }
         int MaxPotions { get; }
+        int MaxBerries { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 

--- a/PokemonGo.RocketAPI/ISettings.cs
+++ b/PokemonGo.RocketAPI/ISettings.cs
@@ -31,6 +31,7 @@ namespace PokemonGo.RocketAPI
         bool useLuckyEggsWhileEvolving { get; }
         bool EvolveAllPokemonAboveIV { get; }
         float EvolveAboveIVValue { get; }
+        int MaxPokeBalls { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 

--- a/PokemonGo.RocketAPI/ISettings.cs
+++ b/PokemonGo.RocketAPI/ISettings.cs
@@ -34,6 +34,7 @@ namespace PokemonGo.RocketAPI
         int MaxPokeBalls { get; }
         int MaxPotions { get; }
         int MaxBerries { get; }
+        int MaxRevives { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 

--- a/PokemonGo.RocketAPI/ISettings.cs
+++ b/PokemonGo.RocketAPI/ISettings.cs
@@ -32,6 +32,7 @@ namespace PokemonGo.RocketAPI
         bool EvolveAllPokemonAboveIV { get; }
         float EvolveAboveIVValue { get; }
         int MaxPokeBalls { get; }
+        int MaxPotions { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 


### PR DESCRIPTION
Creates a group out of all pokeball types and recycles the balls based on the total count, keeping the best balls available at all times. 

It's possible to add the same logic for other item types, such as potions, invoking the `GetGroupedItemsToRecycle` method.