### PR TITLE
Use InvariantCulture to parse GPX values

### DIFF
--- a/PoGo.NecroBot.Logic/Navigation.cs
+++ b/PoGo.NecroBot.Logic/Navigation.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using PoGo.NecroBot.Logic.Utils;
 using PokemonGo.RocketAPI;
 using POGOProtos.Networking.Responses;
+using System.Globalization;
 
 #endregion
 
@@ -88,7 +89,7 @@ namespace PoGo.NecroBot.Logic
         {
             //PlayerUpdateResponse result = null;
 
-            var targetLocation = new GeoCoordinate(Convert.ToDouble(trk.Lat), Convert.ToDouble(trk.Lon));
+            var targetLocation = new GeoCoordinate(Convert.ToDouble(trk.Lat, CultureInfo.InvariantCulture), Convert.ToDouble(trk.Lon, CultureInfo.InvariantCulture));
 
             var speedInMetersPerSecond = walkingSpeedInKilometersPerHour/3.6;
 
@@ -99,7 +100,7 @@ namespace PoGo.NecroBot.Logic
             var nextWaypointBearing = LocationUtils.DegreeBearing(sourceLocation, targetLocation);
             var nextWaypointDistance = speedInMetersPerSecond;
             var waypoint = LocationUtils.CreateWaypoint(sourceLocation, nextWaypointDistance, nextWaypointBearing,
-                Convert.ToDouble(trk.Ele));
+                Convert.ToDouble(trk.Ele, CultureInfo.InvariantCulture));
 
             //Initial walking
 

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -10,6 +10,7 @@ using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Utils;
 using PokemonGo.RocketAPI.Extensions;
 using POGOProtos.Map.Fort;
+using System.Globalization;
 
 #endregion
 
@@ -37,8 +38,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                     {
                         var nextPoint = trackPoints.ElementAt(curTrkPt);
                         var distance = LocationUtils.CalculateDistanceInMeters(ctx.Client.CurrentLatitude,
-                            ctx.Client.CurrentLongitude, Convert.ToDouble(nextPoint.Lat),
-                            Convert.ToDouble(nextPoint.Lon));
+                            ctx.Client.CurrentLongitude, Convert.ToDouble(nextPoint.Lat, CultureInfo.InvariantCulture),
+                            Convert.ToDouble(nextPoint.Lon, CultureInfo.InvariantCulture));
 
                         if (distance > 5000)
                         {


### PR DESCRIPTION
GPX files weren't working with regional settings not using . as decimal seperator.
Thus, I have added CultureInfo.InvariantCulture to all Convert.ToDouble calls related to GPX.