### PR TITLE
KeepMinDuplicatePokemon can now be set to zero

### DIFF
--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -71,7 +71,7 @@ namespace PoGo.NecroBot.Logic
             {
                 var results = new List<PokemonData>();
                 var pokemonsThatCanBeTransfered = pokemonList.GroupBy(p => p.PokemonId)
-                    .Where(x => x.Count() > 2).ToList();
+                    .Where(x => x.Count() > _logicClient.Settings.KeepMinDuplicatePokemon).ToList();
 
                 var myPokemonSettings = await GetPokemonSettings();
                 var pokemonSettings = myPokemonSettings.ToList();
@@ -114,7 +114,7 @@ namespace PoGo.NecroBot.Logic
             {
                 return pokemonList
                     .GroupBy(p => p.PokemonId)
-                    .Where(x => x.Count() > 1)
+                    .Where(x => x.Count() > 0)
                     .SelectMany(
                         p =>
                             p.OrderByDescending(PokemonInfo.CalculatePokemonPerfection)
@@ -124,7 +124,7 @@ namespace PoGo.NecroBot.Logic
             }
             return pokemonList
                 .GroupBy(p => p.PokemonId)
-                .Where(x => x.Count() > 1)
+                .Where(x => x.Count() > 0)
                 .SelectMany(
                     p =>
                         p.OrderByDescending(x => x.Cp)

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -31,6 +31,9 @@ namespace PoGo.NecroBot.Logic.Tasks
                     ? ctx.Inventory.GetHighestPokemonOfTypeByIv(duplicatePokemon).Result
                     : ctx.Inventory.GetHighestPokemonOfTypeByCp(duplicatePokemon).Result;
 
+                if (bestPokemonOfType == null)
+                    bestPokemonOfType = duplicatePokemon;
+
                 machine.Fire(new TransferPokemonEvent
                 {
                     Id = duplicatePokemon.PokemonId,


### PR DESCRIPTION
Made it possible to transfer Pokemon when you have only one of this type left.
Fixes an error when you wanted to transfer your best Pokemon(last one).

(In case you only want Pokemons reaching your criterion)