### PR TITLE
Fixed a logic error in GetDuplicatePokemonToTransfer & reduced size of GetXpDiff

### DIFF
--- a/PoGo.NecroBot.CLI/App.config
+++ b/PoGo.NecroBot.CLI/App.config
@@ -59,6 +59,9 @@
       <setting name="EvolveAllPokemonWithEnoughCandy" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="KeepPokemonsThatCanEvolve" serializeAs="String">
+        <value>False</value>
+      </setting>
       <setting name="TransferDuplicatePokemon" serializeAs="String">
         <value>True</value>
       </setting>

--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -45,6 +45,7 @@ namespace PoGo.NecroBot.CLI
         public int KeepMinCp => UserSettings.Default.KeepMinCP;
         public double WalkingSpeedInKilometerPerHour => UserSettings.Default.WalkingSpeedInKilometerPerHour;
         public bool EvolveAllPokemonWithEnoughCandy => UserSettings.Default.EvolveAllPokemonWithEnoughCandy;
+        public bool KeepPokemonsThatCanEvolve => UserSettings.Default.KeepPokemonsThatCanEvolve;
         public bool TransferDuplicatePokemon => UserSettings.Default.TransferDuplicatePokemon;
         public int DelayBetweenPokemonCatch => UserSettings.Default.DelayBetweenPokemonCatch;
         public bool UsePokemonToNotCatchFilter => UserSettings.Default.UsePokemonToNotCatchFilter;

--- a/PoGo.NecroBot.CLI/UserSettings.Designer.cs
+++ b/PoGo.NecroBot.CLI/UserSettings.Designer.cs
@@ -142,7 +142,22 @@ namespace PoGo.NecroBot.CLI {
                 this["EvolveAllPokemonWithEnoughCandy"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool KeepPokemonsThatCanEvolve
+        {
+            get
+            {
+                return ((bool)(this["KeepPokemonsThatCanEvolve"]));
+            }
+            set
+            {
+                this["KeepPokemonsThatCanEvolve"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]

--- a/PoGo.NecroBot.CLI/UserSettings.settings
+++ b/PoGo.NecroBot.CLI/UserSettings.settings
@@ -1,7 +1,5 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)"
-              GeneratedClassNamespace="PokemonGo.RocketAPI.Console" GeneratedClassName="UserSettings">
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="PoGo.NecroBot.CLI" GeneratedClassName="UserSettings">
   <Profiles />
   <Settings>
     <Setting Name="AuthType" Type="System.String" Scope="User">
@@ -32,6 +30,9 @@
       <Value Profile="(Default)">50</Value>
     </Setting>
     <Setting Name="EvolveAllPokemonWithEnoughCandy" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="KeepPokemonsThatCanEvolve" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="TransferDuplicatePokemon" Type="System.Boolean" Scope="User">

--- a/PoGo.NecroBot.CLI/UserSettings.settings
+++ b/PoGo.NecroBot.CLI/UserSettings.settings
@@ -1,5 +1,5 @@
 ﻿<?xml version='1.0' encoding='utf-8'?>
-<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="PoGo.NecroBot.CLI" GeneratedClassName="UserSettings">
+<SettingsFile xmlns="http://schemas.microsoft.com/VisualStudio/2004/01/settings" CurrentProfile="(Default)" GeneratedClassNamespace="PokemonGo.RocketAPI.Console" GeneratedClassName="UserSettings">
   <Profiles />
   <Settings>
     <Setting Name="AuthType" Type="System.String" Scope="User">

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -14,6 +14,7 @@ namespace PoGo.NecroBot.Logic
         int KeepMinCp { get; }
         double WalkingSpeedInKilometerPerHour { get; }
         bool EvolveAllPokemonWithEnoughCandy { get; }
+        bool KeepPokemonsThatCanEvolve { get; }
         bool TransferDuplicatePokemon { get; }
         int DelayBetweenPokemonCatch { get; }
         bool UsePokemonToNotCatchFilter { get; }

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -83,10 +83,11 @@ namespace PoGo.NecroBot.Logic
                 {
                     var settings = pokemonSettings.Single(x => x.PokemonId == pokemon.Key);
                     var familyCandy = pokemonFamilies.Single(x => settings.FamilyId == x.FamilyId);
-                    var amountToSkip = _client.Settings.KeepMinDuplicatePokemon;
+                    var amountToSkip = _logicClient.Settings.KeepMinDuplicatePokemon;
+                    var amountPossible = familyCandy.Candy / settings.CandyToEvolve;
 
-                    if (settings.CandyToEvolve > 0 && familyCandy.Candy / settings.CandyToEvolve > amountToSkip)
-                        amountToSkip = familyCandy.Candy / settings.CandyToEvolve;
+                    if (settings.CandyToEvolve > 0 && amountPossible > amountToSkip)
+                        amountToSkip = amountPossible;
 
                     if (prioritizeIVoverCp)
                     {

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -83,13 +83,11 @@ namespace PoGo.NecroBot.Logic
                 {
                     var settings = pokemonSettings.Single(x => x.PokemonId == pokemon.Key);
                     var familyCandy = pokemonFamilies.Single(x => settings.FamilyId == x.FamilyId);
-                    if (settings.CandyToEvolve == 0)
-                        continue;
+                    var amountToSkip = _client.Settings.KeepMinDuplicatePokemon;
 
-                    var amountToSkip = familyCandy.Candy/settings.CandyToEvolve;
-                    amountToSkip = amountToSkip > _logicClient.Settings.KeepMinDuplicatePokemon
-                        ? amountToSkip
-                        : _logicClient.Settings.KeepMinDuplicatePokemon;
+                    if (settings.CandyToEvolve > 0 && familyCandy.Candy / settings.CandyToEvolve > amountToSkip)
+                        amountToSkip = familyCandy.Candy / settings.CandyToEvolve;
+
                     if (prioritizeIVoverCp)
                     {
                         results.AddRange(pokemonList.Where(x => x.PokemonId == pokemon.Key)

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -13,7 +13,7 @@ namespace PoGo.NecroBot.Logic.Tasks
         public static void Execute(Context ctx, StateMachine machine)
         {
             var duplicatePokemons =
-                ctx.Inventory.GetDuplicatePokemonToTransfer(false, ctx.LogicSettings.PrioritizeIvOverCp,
+                ctx.Inventory.GetDuplicatePokemonToTransfer(ctx.LogicSettings.KeepPokemonsThatCanEvolve, ctx.LogicSettings.PrioritizeIvOverCp,
                     ctx.LogicSettings.PokemonsNotToTransfer).Result;
 
             foreach (var duplicatePokemon in duplicatePokemons)

--- a/PoGo.NecroBot.Logic/Utils/Statistics.cs
+++ b/PoGo.NecroBot.Logic/Utils/Statistics.cs
@@ -73,88 +73,13 @@ namespace PoGo.NecroBot.Logic.Utils
 
         public static int GetXpDiff(int level)
         {
-            switch (level)
+            if (level > 0 && level <= 40)
             {
-                case 1:
-                    return 0;
-                case 2:
-                    return 1000;
-                case 3:
-                    return 2000;
-                case 4:
-                    return 3000;
-                case 5:
-                    return 4000;
-                case 6:
-                    return 5000;
-                case 7:
-                    return 6000;
-                case 8:
-                    return 7000;
-                case 9:
-                    return 8000;
-                case 10:
-                    return 9000;
-                case 11:
-                    return 10000;
-                case 12:
-                    return 10000;
-                case 13:
-                    return 10000;
-                case 14:
-                    return 10000;
-                case 15:
-                    return 15000;
-                case 16:
-                    return 20000;
-                case 17:
-                    return 20000;
-                case 18:
-                    return 20000;
-                case 19:
-                    return 25000;
-                case 20:
-                    return 25000;
-                case 21:
-                    return 50000;
-                case 22:
-                    return 75000;
-                case 23:
-                    return 100000;
-                case 24:
-                    return 125000;
-                case 25:
-                    return 150000;
-                case 26:
-                    return 190000;
-                case 27:
-                    return 200000;
-                case 28:
-                    return 250000;
-                case 29:
-                    return 300000;
-                case 30:
-                    return 350000;
-                case 31:
-                    return 500000;
-                case 32:
-                    return 500000;
-                case 33:
-                    return 750000;
-                case 34:
-                    return 1000000;
-                case 35:
-                    return 1250000;
-                case 36:
-                    return 1500000;
-                case 37:
-                    return 2000000;
-                case 38:
-                    return 2500000;
-                case 39:
-                    return 1000000;
-                case 40:
-                    return 1000000;
+                int[] xpTable = { 0, 1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000,
+                    10000, 10000, 10000, 10000, 15000, 20000, 20000, 20000, 25000, 25000,
+                    50000, 75000, 100000, 125000, 150000, 190000, 200000, 250000, 300000, 350000,
+                    500000, 500000, 750000, 1000000, 1250000, 1500000, 2000000, 2500000, 1000000, 1000000};
+                return xpTable[level - 1];
             }
             return 0;
         }


### PR DESCRIPTION
With KeepPokemonsThatCanEvolve=true it also kept all pokemons that couldn't evolve. Added KeepPokemonsThatCanEvolve to Settings