### PR TITLE
Fixed divide by zero in GetDuplicatePokemonToTransfer

### DIFF
--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -84,10 +84,13 @@ namespace PoGo.NecroBot.Logic
                     var settings = pokemonSettings.Single(x => x.PokemonId == pokemon.Key);
                     var familyCandy = pokemonFamilies.Single(x => settings.FamilyId == x.FamilyId);
                     var amountToSkip = _logicClient.Settings.KeepMinDuplicatePokemon;
-                    var amountPossible = familyCandy.Candy / settings.CandyToEvolve;
 
-                    if (settings.CandyToEvolve > 0 && amountPossible > amountToSkip)
-                        amountToSkip = amountPossible;
+                    if (settings.CandyToEvolve > 0)
+                    {
+                        var amountPossible = familyCandy.Candy / settings.CandyToEvolve;
+                        if (amountPossible > amountToSkip)
+                            amountToSkip = amountPossible;
+                    }
 
                     if (prioritizeIVoverCp)
                     {


### PR DESCRIPTION
I still prefer my oneliner
`if (settings.CandyToEvolve > 0 && familyCandy.Candy / settings.CandyToEvolve > amountToSkip)
                        amountToSkip = familyCandy.Candy / settings.CandyToEvolve;`

up to you which one you want to implement.