### PR TITLE
Don't attempt to catch a pokemon if there are no pokeballs

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.Logging;
 using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Utils;
@@ -19,6 +20,18 @@ namespace PoGo.NecroBot.Logic.Tasks
     {
         public static void Execute(Context ctx, StateMachine machine, EncounterResponse encounter, MapPokemon pokemon)
         {
+            var invResp = ctx.Client.Inventory.GetInventory();
+            var invRespRes = invResp.Result;
+            if (invRespRes.Success)
+            {
+                var items = invResp.Result.InventoryDelta.InventoryItems;
+                if(items.Select(rawItem => rawItem.InventoryItemData.Item).Where(item => item.ItemId == ItemId.ItemPokeBall || item.ItemId == ItemId.ItemGreatBall || item.ItemId == ItemId.ItemUltraBall || item.ItemId == ItemId.ItemMasterBall).All(item => item.Count == 0))
+                {
+                    Logger.Write("Encountered a pokemon, but there are no pokeballs!", LogLevel.Warning);
+                    return;
+                }
+            }
+
             CatchPokemonResponse caughtPokemonResponse;
             var attemptCounter = 1;
             do


### PR DESCRIPTION
Checks to see if there are any pokeballs (normal, great, ultra, master) in the player's inventory. If not, it logs a warning message and cancels the pokemon catch task.