### PR TITLE
Fixed KeepMinIvPercentage's usage

### DIFF
--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -61,7 +61,8 @@ namespace PoGo.NecroBot.Logic
 
             var pokemonList =
                 myPokemon.Where(
-                    p => p.DeployedFortId == string.Empty && p.Favorite == 0 && p.Cp < _logicClient.Settings.KeepMinCp)
+                    p => p.DeployedFortId == string.Empty && PokemonInfo.CalculatePokemonPerfection(p) < 100 &&
+                         (p.Favorite == 0 && p.Cp < _logicClient.Settings.KeepMinCp || PokemonInfo.CalculatePokemonPerfection(p) < _logicClient.Settings.KeepMinIvPercentage))
                     .ToList();
             if (filter != null)
             {


### PR DESCRIPTION
Currently KeepMinIvPercentage is only being used in the UseBerry logic and I have added it in for the transfer duplicates. Now iit will keep pokemon >= 85 or pokemon >= 1000; [Values specified by your settings.]
I also added keeping of pokemon with 100% IV because some players were complaining about losing their 2nd 100% Eevee.

