### PR TITLE
Added MultiProfile via CommandLine parameter

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -34,11 +34,15 @@ namespace PoGo.NecroBot.CLI
             }
         }
 
-        private static void Main()
+        private static void Main(string[] args)
         {
-            Logger.SetLogger(new ConsoleLogger(LogLevel.Info));
+            string subPath = "";
+            if (args.Length > 0)
+                subPath = "\\" + args[0];
 
-            GlobalSettings settings = GlobalSettings.Load("\\config\\config.json");
+            Logger.SetLogger(new ConsoleLogger(LogLevel.Info), subPath);
+
+            GlobalSettings settings = GlobalSettings.Load(subPath);
 
             var machine = new StateMachine();
             var stats = new Statistics();

--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -73,19 +73,15 @@ namespace PoGo.NecroBot.CLI
     public class GlobalSettings
     {
         public static GlobalSettings Default => new GlobalSettings();
-
-        private static string GetAuthPath(string path)
-        {
-            var fullPath = Directory.GetCurrentDirectory() + path;
-            string folder = Path.GetDirectoryName(fullPath);
-            folder += "\\auth.json";
-
-            return folder;
-        }
+        public static string ProfilePath;
+        public static string ConfigPath;
 
         public static GlobalSettings Load(string path)
         {
-            var fullPath = Directory.GetCurrentDirectory() + path;
+            ProfilePath = Directory.GetCurrentDirectory() + path;
+            ConfigPath = ProfilePath + "\\config";
+
+            var fullPath = ConfigPath + "\\config.json";
 
             GlobalSettings settings = null;
             if (File.Exists(fullPath))
@@ -104,18 +100,17 @@ namespace PoGo.NecroBot.CLI
             {
                 settings = new GlobalSettings();
             }
-
-            settings.Save(path);
-            settings.Auth.Load(GetAuthPath(path));
+            Logger.Write($"nigger {fullPath} {ConfigPath} {ProfilePath}");
+            settings.Save(fullPath);
+            settings.Auth.Load(ConfigPath + "\\auth.json");
 
             return settings;
         }
 
-        public void Save(string path)
+        public void Save(string fullPath)
         {
             var output = JsonConvert.SerializeObject(this, Formatting.Indented, new StringEnumConverter { CamelCaseText = true });
 
-            var fullPath = Directory.GetCurrentDirectory() + path;
             string folder = Path.GetDirectoryName(fullPath);
             if (!Directory.Exists(folder))
             {

--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -100,7 +100,6 @@ namespace PoGo.NecroBot.CLI
             {
                 settings = new GlobalSettings();
             }
-            Logger.Write($"nigger {fullPath} {ConfigPath} {ProfilePath}");
             settings.Save(fullPath);
             settings.Auth.Load(ConfigPath + "\\auth.json");
 

--- a/PoGo.NecroBot.Logic/Logging/Logger.cs
+++ b/PoGo.NecroBot.Logic/Logging/Logger.cs
@@ -10,16 +10,17 @@ namespace PoGo.NecroBot.Logic.Logging
     public static class Logger
     {
         private static ILogger _logger;
+        private static string _subPath;
 
         private static void Log(string message)
         {
             // maybe do a new log rather than appending?
-            Directory.CreateDirectory(Directory.GetCurrentDirectory() + "\\Logs");
+            Directory.CreateDirectory(Directory.GetCurrentDirectory() + _subPath + "\\Logs");
 
 
             using (
                 var log =
-                    File.AppendText(Directory.GetCurrentDirectory() +
+                    File.AppendText(Directory.GetCurrentDirectory() + _subPath +
                                     $"\\Logs\\NecroBot-{DateTime.Today.ToString("yyyy-MM-dd")}-{DateTime.Now.ToString("HH")}.txt")
                 )
             {
@@ -34,9 +35,10 @@ namespace PoGo.NecroBot.Logic.Logging
         ///     unset.
         /// </summary>
         /// <param name="logger"></param>
-        public static void SetLogger(ILogger logger)
+        public static void SetLogger(ILogger logger, string subPath = "")
         {
             _logger = logger;
+            _subPath = subPath;
             Log($"Initializing Rocket logger at time {DateTime.Now}...");
         }
 


### PR DESCRIPTION
`cli.exe <Profile>`
if no parameter is given, the standard paths are beeing used.
if Profile is set, it will use configs/logs from _CurrentDir\<Profile>\_
any path specific functions should use **GlobalSettings.ProfilePath** and
**GlobalSettings.ConfigPath**