### PR TITLE
Egg incubation

### DIFF
--- a/PoGo.NecroBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.NecroBot.CLI/ConsoleEventListener.cs
@@ -58,6 +58,14 @@ namespace PoGo.NecroBot.CLI
             Logger.Write($"{evt.Count}x {evt.Id}", LogLevel.Recycling);
         }
 
+        public void HandleEvent(EggIncubatorStatusEvent evt, Context ctx)
+        {
+            if (evt.WasAddedNow)
+                Logger.Write($"Putting egg in incubator: {evt.KmRemaining:0.00}km left");
+            else
+                Logger.Write($"Incubator status update: {evt.KmRemaining:0.00}km left");
+        }
+
         public void HandleEvent(FortUsedEvent evt, Context ctx)
         {
             Logger.Write($"XP: {evt.Exp}, Gems: {evt.Gems}, Items: {evt.Items}", LogLevel.Pokestop);

--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -170,6 +170,7 @@ namespace PoGo.NecroBot.CLI
         public int MaxTravelDistanceInMeters = 1000;
         public bool PrioritizeIvOverCp = true;
         public bool TransferDuplicatePokemon = true;
+        public bool UseEggIncubators = true;
         public bool UseGpxPathing = false;
         public bool UseLuckyEggsWhileEvolving = false;
         public bool UsePokemonToNotCatchFilter = false;
@@ -286,6 +287,7 @@ namespace PoGo.NecroBot.CLI
         public bool EvolveAllPokemonWithEnoughCandy => _settings.EvolveAllPokemonWithEnoughCandy;
         public bool KeepPokemonsThatCanEvolve => _settings.KeepPokemonsThatCanEvolve;
         public bool TransferDuplicatePokemon => _settings.TransferDuplicatePokemon;
+        public bool UseEggIncubators => _settings.UseEggIncubators;
         public int DelayBetweenPokemonCatch => _settings.DelayBetweenPokemonCatch;
         public bool UsePokemonToNotCatchFilter => _settings.UsePokemonToNotCatchFilter;
         public int KeepMinDuplicatePokemon => _settings.KeepMinDuplicatePokemon;

--- a/PoGo.NecroBot.Logic/Event/EggIncubatorStatusEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/EggIncubatorStatusEvent.cs
@@ -1,0 +1,12 @@
+﻿namespace PoGo.NecroBot.Logic.Event
+{
+    public class EggIncubatorStatusEvent : IEvent
+    {
+        public string IncubatorId;
+        public bool WasAddedNow;
+        public ulong PokemonId;
+        public double KmToWalk;
+        public double KmRemaining;
+        public double KmWalked => KmToWalk - KmRemaining;
+    }
+}

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -17,6 +17,7 @@ namespace PoGo.NecroBot.Logic
         bool EvolveAllPokemonWithEnoughCandy { get; }
         bool KeepPokemonsThatCanEvolve { get; }
         bool TransferDuplicatePokemon { get; }
+        bool UseEggIncubators { get; }
         int DelayBetweenPokemonCatch { get; }
         bool UsePokemonToNotCatchFilter { get; }
         int KeepMinDuplicatePokemon { get; }

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -168,6 +168,24 @@ namespace PoGo.NecroBot.Logic
             return pokemons.OrderByDescending(PokemonInfo.CalculatePokemonPerfection).Take(limit);
         }
 
+        public async Task<IEnumerable<PokemonData>> GetEggs()
+        {
+            var inventory = await GetCachedInventory();
+            return
+                inventory.InventoryDelta.InventoryItems.Select(i => i.InventoryItemData?.PokemonData)
+                    .Where(p => p != null && p.IsEgg);
+        }
+
+        public async Task<IEnumerable<EggIncubator>> GetEggIncubators()
+        {
+            var inventory = await GetCachedInventory();
+            return
+                inventory.InventoryDelta.InventoryItems
+                .Where(x => x.InventoryItemData.EggIncubators != null)
+                .SelectMany(i => i.InventoryItemData.EggIncubators.EggIncubator)
+                .Where(i => i != null);
+        }
+
         public async Task<int> GetItemAmountByType(ItemId type)
         {
             var pokeballs = await GetItems();

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Event\ProfileEvent.cs" />
     <Compile Include="Event\TransferPokemonEvent.cs" />
     <Compile Include="Event\UseBerryEvent.cs" />
+    <Compile Include="Event\EggIncubatorStatusEvent.cs" />
     <Compile Include="Inventory.cs" />
     <Compile Include="Logging\Logger.cs" />
     <Compile Include="LogicClient.cs" />

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Event\UseLuckyEggEvent.cs" />
     <Compile Include="State\VersionCheckState.cs" />
     <Compile Include="Event\WarnEvent.cs" />
+    <Compile Include="Tasks\UseIncubatorsTask.cs" />
     <Compile Include="Tasks\UseNearbyPokestopsTask.cs" />
     <Compile Include="Utils\GPXReader.cs" />
     <Compile Include="Logging\ILogger.cs" />

--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -27,6 +27,11 @@ namespace PoGo.NecroBot.Logic.State
 
             await RecycleItemsTask.Execute(ctx, machine);
 
+            if (ctx.LogicSettings.UseEggIncubators)
+            {
+                await UseIncubatorsTask.Execute(ctx, machine);
+            }
+
             if (ctx.LogicSettings.UseGpxPathing)
             {
                 await FarmPokestopsGpxTask.Execute(ctx, machine);

--- a/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
@@ -1,0 +1,57 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using PoGo.NecroBot.Logic.Logging;
+using PoGo.NecroBot.Logic.State;
+using POGOProtos.Inventory.Item;
+
+namespace PoGo.NecroBot.Logic.Tasks
+{
+    class UseIncubatorsTask
+    {
+        public static async Task Execute(Context ctx, StateMachine machine)
+        {
+            // Refresh inventory so that the player stats are fresh
+            await ctx.Inventory.RefreshCachedInventory();
+
+            var playerStats = (await ctx.Inventory.GetPlayerStats()).FirstOrDefault();
+            if (playerStats == null)
+                return;
+
+            var kmWalked = playerStats.KmWalked;
+
+            var incubators = (await ctx.Inventory.GetEggIncubators())
+                .Where(x => x.UsesRemaining > 0 || x.ItemId == ItemId.ItemIncubatorBasicUnlimited)
+                .OrderByDescending(x => x.ItemId == ItemId.ItemIncubatorBasicUnlimited)
+                .ToList();
+
+            var unusedEggs = (await ctx.Inventory.GetEggs())
+                .Where(x => string.IsNullOrEmpty(x.EggIncubatorId))
+                .OrderBy(x => x.EggKmWalkedTarget - x.EggKmWalkedStart)
+                .ToList();
+
+            foreach (var incubator in incubators)
+            {
+                if (incubator.PokemonId == 0)
+                {
+                    // Unlimited incubators prefer short eggs, limited incubators prefer long eggs
+                    var egg = incubator.ItemId == ItemId.ItemIncubatorBasicUnlimited
+                        ? unusedEggs.FirstOrDefault()
+                        : unusedEggs.LastOrDefault();
+
+                    if (egg == null)
+                        continue;
+
+                    var response = await ctx.Client.Inventory.UseItemEggIncubator(incubator.Id, egg.Id);
+                    Logger.Write($"Putting egg in incubator ({response.EggIncubator.TargetKmWalked - kmWalked:0.00}km left)");
+
+                    unusedEggs.Remove(egg);
+                    await Task.Delay(500);
+                }
+                else
+                {
+                    Logger.Write($"Incubator status update: {incubator.TargetKmWalked - kmWalked:0.00}km left");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Automatic use of egg incubators before every farming run, with setting for enabling (default=on).

Currently not executed in-between pokestops, but that would be a good next step. Simply add up the distances between stops and when enough of a distance (1km+) has been traveled, check incubators.