### PR TITLE
Fix for trying to get nearby pokestops when using GPX. 

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -70,7 +70,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                         i.CooldownCompleteTimestampMs < DateTime.UtcNow.ToUnixTime() &&
                         ( // Make sure PokeStop is within 40 meters or else it is pointless to hit it
                             LocationUtils.CalculateDistanceInMeters(
-                                ctx.Settings.DefaultLatitude, ctx.Settings.DefaultLongitude,
+                                ctx.Client.CurrentLatitude, ctx.Client.CurrentLongitude,
                                 i.Latitude, i.Longitude) < 40) ||
                         ctx.LogicSettings.MaxTravelDistanceInMeters == 0
                 );


### PR DESCRIPTION
Was broken from fix for #489. Updated to use Current instead of Default Lat/Long.