### PR TITLE
Fix: Move RenamePokemonTask to after evolving and transferring in FarmState.cs

### DIFF
--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -11,7 +11,6 @@ namespace PoGo.NecroBot.Logic.State
     {
         public async Task<IState> Execute(Context ctx, StateMachine machine)
         {
-            
 
             await DisplayPokemonStatsTask.Execute(ctx, machine);
 

--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -11,7 +11,7 @@ namespace PoGo.NecroBot.Logic.State
     {
         public async Task<IState> Execute(Context ctx, StateMachine machine)
         {
-            await RenamePokemonTask.Execute(ctx, machine);
+            
 
             await DisplayPokemonStatsTask.Execute(ctx, machine);
 
@@ -23,6 +23,11 @@ namespace PoGo.NecroBot.Logic.State
             if (ctx.LogicSettings.TransferDuplicatePokemon)
             {
                 await TransferDuplicatePokemonTask.Execute(ctx, machine);
+            }
+
+            if (ctx.LogicSettings.RenameAboveIv)
+            {
+                await RenamePokemonTask.Execute(ctx, machine);
             }
 
             await RecycleItemsTask.Execute(ctx, machine);


### PR DESCRIPTION
Fix: 

Move RenamePokemonTask to after evolving and transferring in FarmState.cs, 

Also wrap in IF block that checks if RenameAboveIV setting is set to true before executing RenamePokemonTask