### PR TITLE
Fix: Move RenamePokemonTask to after evolving and transferring

### DIFF
--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -11,7 +11,6 @@ namespace PoGo.NecroBot.Logic.State
     {
         public async Task<IState> Execute(Context ctx, StateMachine machine)
         {
-            
 
             await DisplayPokemonStatsTask.Execute(ctx, machine);
 

--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -11,7 +11,7 @@ namespace PoGo.NecroBot.Logic.State
     {
         public async Task<IState> Execute(Context ctx, StateMachine machine)
         {
-            await RenamePokemonTask.Execute(ctx, machine);
+            
 
             await DisplayPokemonStatsTask.Execute(ctx, machine);
 
@@ -23,6 +23,11 @@ namespace PoGo.NecroBot.Logic.State
             if (ctx.LogicSettings.TransferDuplicatePokemon)
             {
                 await TransferDuplicatePokemonTask.Execute(ctx, machine);
+            }
+
+            if (ctx.LogicSettings.RenameAboveIv)
+            {
+                await RenamePokemonTask.Execute(ctx, machine);
             }
 
             await RecycleItemsTask.Execute(ctx, machine);

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -92,7 +92,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                             await RecycleItemsTask.Execute(ctx, machine);
 
-                            if (ctx.LogicSettings.EvolveAllPokemonWithEnoughCandy || 
+                            if (ctx.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
                                 ctx.LogicSettings.EvolveAllPokemonAboveIv)
                             {
                                 await EvolvePokemonTask.Execute(ctx, machine);

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -92,7 +92,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                             await RecycleItemsTask.Execute(ctx, machine);
 
-                            if (ctx.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
+                            if (ctx.LogicSettings.EvolveAllPokemonWithEnoughCandy || 
                                 ctx.LogicSettings.EvolveAllPokemonAboveIv)
                             {
                                 await EvolvePokemonTask.Execute(ctx, machine);
@@ -101,6 +101,11 @@ namespace PoGo.NecroBot.Logic.Tasks
                             if (ctx.LogicSettings.TransferDuplicatePokemon)
                             {
                                 await TransferDuplicatePokemonTask.Execute(ctx, machine);
+                            }
+
+                            if (ctx.LogicSettings.RenameAboveIv)
+                            {
+                                await RenamePokemonTask.Execute(ctx, machine);
                             }
                         }
 

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -103,7 +103,6 @@ namespace PoGo.NecroBot.Logic.Tasks
                     {
                         var refreshCachedInventory = await ctx.Inventory.RefreshCachedInventory();
                     }
-                    await RenamePokemonTask.Execute(ctx, machine);
                     await RecycleItemsTask.Execute(ctx, machine);
                     if (ctx.LogicSettings.EvolveAllPokemonWithEnoughCandy || ctx.LogicSettings.EvolveAllPokemonAboveIv)
                     {
@@ -112,6 +111,10 @@ namespace PoGo.NecroBot.Logic.Tasks
                     if (ctx.LogicSettings.TransferDuplicatePokemon)
                     {
                         await TransferDuplicatePokemonTask.Execute(ctx, machine);
+                    }
+                    if (ctx.LogicSettings.RenameAboveIv)
+                    {
+                        await RenamePokemonTask.Execute(ctx, machine);
                     }
                 }
             }


### PR DESCRIPTION
Wrapped RenamePokemonTask in a IF block to check if RenameAboveIV settings is set to true before executing RenamePokemon Task

Added RenamePokemonTask  to FarmPokestopsGPXTask.cs

Moved RenamePokemonTask to after evolving and transfering in FarmState.cs, FarmPokestopsTask.cs and FarmPokestopsGPXTask.cs

