### PR TITLE
Add configurable minimum number of evolvable pokemon for lucky egg usage

### DIFF
--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -176,6 +176,7 @@ namespace PoGo.NecroBot.CLI
         public bool UseEggIncubators = true;
         public bool UseGpxPathing = false;
         public bool UseLuckyEggsWhileEvolving = false;
+        public int UseLuckyEggsMinPokemonAmount = 30;
         public bool UsePokemonToNotCatchFilter = false;
         public double WalkingSpeedInKilometerPerHour = 50;
         public int AmountOfPokemonToDisplayOnStart = 10;
@@ -299,6 +300,7 @@ namespace PoGo.NecroBot.CLI
         public string GpxFile => _settings.GpxFile;
         public bool UseGpxPathing => _settings.UseGpxPathing;
         public bool UseLuckyEggsWhileEvolving => _settings.UseLuckyEggsWhileEvolving;
+        public int UseLuckyEggsMinPokemonAmount => _settings.UseLuckyEggsMinPokemonAmount;
         public bool EvolveAllPokemonAboveIv => _settings.EvolveAllPokemonAboveIv;
         public float EvolveAboveIvValue => _settings.EvolveAboveIvValue;
         public bool RenameAboveIv => _settings.RenameAboveIv;

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -26,6 +26,7 @@ namespace PoGo.NecroBot.Logic
         bool UseGpxPathing { get; }
         string GpxFile { get; }
         bool UseLuckyEggsWhileEvolving { get; }
+        int UseLuckyEggsMinPokemonAmount { get; }
         bool EvolveAllPokemonAboveIv { get; }
         float EvolveAboveIvValue { get; }
         bool RenameAboveIv { get; }

--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -26,6 +26,11 @@ namespace PoGo.NecroBot.Logic.Tasks
                 {
                     await UseLuckyEgg(ctx.Client, ctx.Inventory, machine);
                 }
+                else
+                {
+                    // Wait until we have enough pokemon
+                    return;
+                }
             }
 
             foreach (var pokemon in pokemonToEvolve)

--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -18,14 +18,16 @@ namespace PoGo.NecroBot.Logic.Tasks
         private static DateTime _lastLuckyEggTime;
         public static async Task Execute(Context ctx, StateMachine machine)
         {
+            var pokemonToEvolveTask = await ctx.Inventory.GetPokemonToEvolve(ctx.LogicSettings.PokemonsToEvolve);
+            var pokemonToEvolve = pokemonToEvolveTask;
             if (ctx.LogicSettings.UseLuckyEggsWhileEvolving)
             {
-                await UseLuckyEgg(ctx.Client, ctx.Inventory, machine);
+                if (pokemonToEvolve.Count() >= ctx.LogicSettings.UseLuckyEggsMinPokemonAmount)
+                {
+                    await UseLuckyEgg(ctx.Client, ctx.Inventory, machine);
+                }
             }
 
-            var pokemonToEvolveTask = await ctx.Inventory.GetPokemonToEvolve(ctx.LogicSettings.PokemonsToEvolve);
-
-            var pokemonToEvolve = pokemonToEvolveTask;
             foreach (var pokemon in pokemonToEvolve)
             {
                 var evolveResponse = await ctx.Client.Inventory.EvolvePokemon(pokemon.Id);


### PR DESCRIPTION
Ensures that a minimum number of pokemon are ready to be evolved before using a lucky egg. See #632 