### PR TITLE
fixed path for multiprofile logs

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -42,7 +42,7 @@ namespace PoGo.NecroBot.CLI
             if (args.Length > 0)
                 subPath = Path.DirectorySeparatorChar + args[0];
 
-            Logger.SetLogger(new ConsoleLogger(LogLevel.Info));
+            Logger.SetLogger(new ConsoleLogger(LogLevel.Info), subPath);
 
             GlobalSettings settings = GlobalSettings.Load(subPath);
 


### PR DESCRIPTION
Issue was introduced after this [commit](https://github.com/NecronomiconCoding/NecroBot/commit/e62da1d63025700f10b214f72d412e3cc7c675ad) causing all logs being stored in one file and bot throwing `System.IO.IOException: The process cannot access the file`