### PR TITLE
Dirty 'skip stops until pokeballs < 25' hack.

### DIFF
--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -179,6 +179,7 @@ namespace PoGo.NecroBot.CLI
         public double WalkingSpeedInKilometerPerHour = 50;
         public int AmountOfPokemonToDisplayOnStart = 10;
         public bool RenameAboveIv = false;
+        public bool MinimalStops = false;
         public int WebSocketPort = 14251;
 
         [JsonIgnore]
@@ -302,6 +303,7 @@ namespace PoGo.NecroBot.CLI
         public bool RenameAboveIv => _settings.RenameAboveIv;
         public int AmountOfPokemonToDisplayOnStart => _settings.AmountOfPokemonToDisplayOnStart;
         public string TranslationLanguageCode => _settings.TranslationLanguageCode;
+        public bool MinimalStops => _settings.MinimalStops;
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter => _settings.ItemRecycleFilter;
         public ICollection<PokemonId> PokemonsToEvolve => _settings.PokemonsToEvolve;
         public ICollection<PokemonId> PokemonsNotToTransfer => _settings.PokemonsNotToTransfer;

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -30,6 +30,7 @@ namespace PoGo.NecroBot.Logic
         bool RenameAboveIv { get; }
         int AmountOfPokemonToDisplayOnStart { get; }
         string TranslationLanguageCode { get; }
+        bool MinimalStops { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -71,21 +71,26 @@ namespace PoGo.NecroBot.Logic.Tasks
                                 await CatchLurePokemonsTask.Execute(ctx, machine, pokeStop);
                             }
 
-                            var fortSearch =
-                                await ctx.Client.Fort.SearchFort(pokeStop.Id, pokeStop.Latitude, pokeStop.Longitude);
+                            // Dirty hack for pokeball quantity, needs to be pulled out to a isStopNeeded() method to expand other preferences like other minimal items quantity
+                            if (!ctx.LogicSettings.MinimalStops || (ctx.LogicSettings.MinimalStops && (
+                                25 > ctx.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemPokeBall).Result + ctx.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemGreatBall).Result + ctx.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemUltraBall).Result
+                            )))
+                            {
+                                var fortSearch = await ctx.Client.Fort.SearchFort(pokeStop.Id, pokeStop.Latitude, pokeStop.Longitude);
 
-                            if (fortSearch.ExperienceAwarded > 0)
-                            {
-                                machine.Fire(new FortUsedEvent
+                                if (fortSearch.ExperienceAwarded > 0)
                                 {
-                                    Exp = fortSearch.ExperienceAwarded,
-                                    Gems = fortSearch.GemsAwarded,
-                                    Items = StringUtils.GetSummedFriendlyNameOfItemAwardList(fortSearch.ItemsAwarded)
-                                });
-                            }
-                            if (fortSearch.ItemsAwarded.Count > 0)
-                            {
-                                var refreshCachedInventory = ctx.Inventory.RefreshCachedInventory();
+                                    machine.Fire(new FortUsedEvent
+                                    {
+                                        Exp = fortSearch.ExperienceAwarded,
+                                        Gems = fortSearch.GemsAwarded,
+                                        Items = StringUtils.GetSummedFriendlyNameOfItemAwardList(fortSearch.ItemsAwarded)
+                                    });
+                                }
+                                if (fortSearch.ItemsAwarded.Count > 0)
+                                {
+                                    var refreshCachedInventory = ctx.Inventory.RefreshCachedInventory();
+                                }
                             }
 
                             await Task.Delay(1000);
@@ -110,7 +115,15 @@ namespace PoGo.NecroBot.Logic.Tasks
                                 await CatchNearbyPokemonsTask.Execute(ctx, machine);
                                 //Catch Incense Pokemon
                                 await CatchIncensePokemonsTask.Execute(ctx, machine);
-                                await UseNearbyPokestopsTask.Execute(ctx, machine);
+
+                                // Dirty hack for pokeball quantity, needs to be pulled out to a isStopNeeded() method to expand other preferences like other minimal items quantity
+                                if (!ctx.LogicSettings.MinimalStops || (ctx.LogicSettings.MinimalStops && (
+                                    25 > ctx.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemPokeBall).Result + ctx.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemGreatBall).Result + ctx.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemUltraBall).Result
+                                )))
+                                {
+                                    await UseNearbyPokestopsTask.Execute(ctx, machine);
+                                }
+
                                 return true;
                             }
                             );


### PR DESCRIPTION
Could use DRYing, was having issues with Task and await errors with trying to call a plain function for checking the inventory. isStopNeeded() or something similar called in the if's to simplify and remove the large statement would be good cleanup. Can use other logic checks in json to simplify the need for exp from stops if you have a large surplus of pokeballs still.