### PR TITLE
Fix for log files not being put in correct location when a profiles is used

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -42,7 +42,7 @@ namespace PoGo.NecroBot.CLI
             if (args.Length > 0)
                 subPath = Path.DirectorySeparatorChar + args[0];
 
-            Logger.SetLogger(new ConsoleLogger(LogLevel.Info));
+            Logger.SetLogger(new ConsoleLogger(LogLevel.Info), subPath);
 
             GlobalSettings settings = GlobalSettings.Load(subPath);
 


### PR DESCRIPTION
Before all profiles shared the same log file in the root folder.