### PR TITLE
MultiProfiles fix & Individual transfer filter feature

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -42,7 +42,7 @@ namespace PoGo.NecroBot.CLI
             if (args.Length > 0)
                 subPath = Path.DirectorySeparatorChar + args[0];
 
-            Logger.SetLogger(new ConsoleLogger(LogLevel.Info));
+            Logger.SetLogger(new ConsoleLogger(LogLevel.Info), subPath);
 
             GlobalSettings settings = GlobalSettings.Load(subPath);
 

--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -21,7 +21,7 @@ namespace PoGo.NecroBot.CLI
     {
         public AuthSettings()
         {
-            if (File.Exists(Directory.GetCurrentDirectory() 
+            if (File.Exists(GlobalSettings.ConfigPath 
                 + Path.DirectorySeparatorChar +"config"
                 + Path.DirectorySeparatorChar + "auth.json")) return;
             string type;

--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -1,4 +1,4 @@
-﻿#region using directives
+#region using directives
 
 using System;
 using System.Collections.Generic;
@@ -69,7 +69,7 @@ namespace PoGo.NecroBot.CLI
                     PtcPassword = Console.ReadLine();
                 } while (string.IsNullOrEmpty(PtcPassword));
                 Console.Clear();
-                
+
                 Save(FilePath);
             }
         }
@@ -99,17 +99,16 @@ namespace PoGo.NecroBot.CLI
     public class GlobalSettings
     {
         public static GlobalSettings Default => new GlobalSettings();
-        public static string ProfilePath;
-        public static string ConfigPath;
 
         public static GlobalSettings Load(string path)
         {
-            ProfilePath = Directory.GetCurrentDirectory() + path;
-            ConfigPath = ProfilePath + Path.DirectorySeparatorChar + "config";
-
-            var fullPath = ConfigPath + Path.DirectorySeparatorChar + "config.json";
-
             GlobalSettings settings = null;
+
+            settings.ProfilePath = Directory.GetCurrentDirectory() + path;
+            settings.ConfigPath = settings.ProfilePath + Path.DirectorySeparatorChar + "config";
+
+            var fullPath = settings.ConfigPath + Path.DirectorySeparatorChar + "config.json";
+
             if (File.Exists(fullPath))
             {
                 //if the file exists, load the settings
@@ -133,7 +132,7 @@ namespace PoGo.NecroBot.CLI
             }
 
             settings.Save(fullPath);
-            settings.Auth.Load(ConfigPath + Path.DirectorySeparatorChar + "auth.json");
+            settings.Auth.Load(settings.ConfigPath + Path.DirectorySeparatorChar + "auth.json");
 
             return settings;
         }
@@ -176,6 +175,8 @@ namespace PoGo.NecroBot.CLI
         public int AmountOfPokemonToDisplayOnStart = 10;
         public bool RenameAboveIv = false;
         public int WebSocketPort = 14251;
+        public string ProfilePath;
+        public string ConfigPath;
 
         [JsonIgnore]
         internal AuthSettings Auth = new AuthSettings();
@@ -264,6 +265,8 @@ namespace PoGo.NecroBot.CLI
         public double DefaultLatitude => _settings.DefaultLatitude;
         public double DefaultLongitude => _settings.DefaultLongitude;
         public double DefaultAltitude => _settings.DefaultAltitude;
+        public string ProfilePath => _settings.ProfilePath;
+        public string ConfigPath => _settings.ConfigPath;
 
         public string GoogleRefreshToken
         {

--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -238,6 +238,15 @@ namespace PoGo.NecroBot.CLI
                     PokemonId.Pidgey,
                     PokemonId.Rattata
                 };
+
+        public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter = new Dictionary<PokemonId, TransferFilter>
+                {
+                    { PokemonId.Pidgeotto, new TransferFilter(1500, 90, 1)},
+                    { PokemonId.Fearow, new TransferFilter(1500, 90, 2)},
+                    { PokemonId.Golbat, new TransferFilter(1500, 90, 2)},
+                    { PokemonId.Eevee, new TransferFilter(600, 800, 2)},
+                    { PokemonId.Mew, new TransferFilter(0, 0, 10)}
+                };
     }
 
     public class ClientSettings : ISettings
@@ -303,5 +312,6 @@ namespace PoGo.NecroBot.CLI
         public ICollection<PokemonId> PokemonsToEvolve => _settings.PokemonsToEvolve;
         public ICollection<PokemonId> PokemonsNotToTransfer => _settings.PokemonsNotToTransfer;
         public ICollection<PokemonId> PokemonsNotToCatch => _settings.PokemonsToIgnore;
+        public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter => _settings.PokemonsTransferFilter;
     }
 }

--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -265,8 +265,6 @@ namespace PoGo.NecroBot.CLI
         public double DefaultLatitude => _settings.DefaultLatitude;
         public double DefaultLongitude => _settings.DefaultLongitude;
         public double DefaultAltitude => _settings.DefaultAltitude;
-        public string ProfilePath => _settings.ProfilePath;
-        public string ConfigPath => _settings.ConfigPath;
 
         public string GoogleRefreshToken
         {
@@ -290,6 +288,8 @@ namespace PoGo.NecroBot.CLI
         {
             _settings = settings;
         }
+        public string ProfilePath => _settings.ProfilePath;
+        public string ConfigPath => _settings.ConfigPath;
         public bool AutoUpdate => _settings.AutoUpdate;
         public float KeepMinIvPercentage => _settings.KeepMinIvPercentage;
         public int KeepMinCp => _settings.KeepMinCp;

--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -19,37 +19,6 @@ namespace PoGo.NecroBot.CLI
 {
     internal class AuthSettings
     {
-        public AuthSettings()
-        {
-            if (File.Exists(GlobalSettings.ConfigPath 
-                + Path.DirectorySeparatorChar +"config"
-                + Path.DirectorySeparatorChar + "auth.json")) return;
-            string type;
-            do
-            {
-                Console.WriteLine("Please choose your AuthType");
-                Console.WriteLine("(0) for Google Authentication");
-                Console.WriteLine("(1) for Pokemon Trainer Club");
-                type = Console.ReadLine();
-            } while (type != "1" && type != "0");
-            AuthType = type.Equals("0") ? AuthType.Google : AuthType.Ptc;
-            if (AuthType == AuthType.Google)
-            {
-                Console.Clear();
-                return;
-            }
-            do
-            {
-                Console.WriteLine("Username:");
-                PtcUsername = Console.ReadLine();
-            } while (string.IsNullOrEmpty(PtcUsername));
-            do
-            {
-                Console.WriteLine("Password:");
-                PtcPassword = Console.ReadLine();
-            } while (string.IsNullOrEmpty(PtcPassword));
-            Console.Clear();
-        }
         public AuthType AuthType;
         public string GoogleRefreshToken;
         public string PtcUsername;
@@ -75,6 +44,32 @@ namespace PoGo.NecroBot.CLI
             }
             else
             {
+                string type;
+                do
+                {
+                    Console.WriteLine($"Please choose your AuthType");
+                    Console.WriteLine("(0) for Google Authentication");
+                    Console.WriteLine("(1) for Pokemon Trainer Club");
+                    type = Console.ReadLine();
+                } while (type != "1" && type != "0");
+                AuthType = type.Equals("0") ? AuthType.Google : AuthType.Ptc;
+                if (AuthType == AuthType.Google)
+                {
+                    Console.Clear();
+                    return;
+                }
+                do
+                {
+                    Console.WriteLine("Username:");
+                    PtcUsername = Console.ReadLine();
+                } while (string.IsNullOrEmpty(PtcUsername));
+                do
+                {
+                    Console.WriteLine("Password:");
+                    PtcPassword = Console.ReadLine();
+                } while (string.IsNullOrEmpty(PtcPassword));
+                Console.Clear();
+                
                 Save(FilePath);
             }
         }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -8,6 +8,21 @@ using POGOProtos.Inventory.Item;
 
 namespace PoGo.NecroBot.Logic
 {
+    public class TransferFilter
+    {
+        public TransferFilter() { }
+
+        public TransferFilter(int keepMinCp, float keepMinIvPercentage, int keepMinDuplicatePokemon)
+        {
+            this.KeepMinCp = keepMinCp;
+            this.KeepMinIvPercentage = keepMinIvPercentage;
+            this.KeepMinDuplicatePokemon = keepMinDuplicatePokemon;
+        }
+
+        public int KeepMinCp { get; set; }
+        public float KeepMinIvPercentage { get; set; }
+        public int KeepMinDuplicatePokemon { get; set; }
+    };
     public interface ILogicSettings
     {
         bool AutoUpdate { get; }
@@ -39,5 +54,7 @@ namespace PoGo.NecroBot.Logic
         ICollection<PokemonId> PokemonsNotToTransfer { get; }
 
         ICollection<PokemonId> PokemonsNotToCatch { get; }
+
+        Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter { get; }
     }
 }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -46,6 +46,8 @@ namespace PoGo.NecroBot.Logic
         bool RenameAboveIv { get; }
         int AmountOfPokemonToDisplayOnStart { get; }
         string TranslationLanguageCode { get; }
+        string ProfilePath { get; }
+        string ConfigPath { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -23,8 +23,8 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             foreach (var duplicatePokemon in duplicatePokemons)
             {
-                if (duplicatePokemon.Cp >= ctx.LogicSettings.KeepMinCp ||
-                    PokemonInfo.CalculatePokemonPerfection(duplicatePokemon) > ctx.LogicSettings.KeepMinIvPercentage)
+                if (duplicatePokemon.Cp >= ctx.Inventory.GetPokemonTransferFilter(duplicatePokemon.PokemonId).KeepMinCp ||
+                    PokemonInfo.CalculatePokemonPerfection(duplicatePokemon) > ctx.Inventory.GetPokemonTransferFilter(duplicatePokemon.PokemonId).KeepMinIvPercentage)
                 {
                     continue;
                 }


### PR DESCRIPTION
I accidently overwrote (and autoclosed) my previous PR about the MultiProfile fix: https://github.com/NecronomiconCoding/NecroBot/pull/749

So this contains the multiprofile fixes and a brand new feature to use individual transfer filter minimum values for each pokemon.
Example config:
`"PokemonsTransferFilter": {
    "Pidgeotto": {
      "KeepMinCp": 1500,
      "KeepMinIvPercentage": 90.0,
      "KeepMinDuplicatePokemon": 1
    },
    "Fearow": {
      "KeepMinCp": 1500,
      "KeepMinIvPercentage": 90.0,
      "KeepMinDuplicatePokemon": 2
    }
  },`

This comes in handy if you want to transfer all the useless pidgeottos and golbats that are over your default CP limit. Or if you want to keep eevees with 600 cp which is under a cp limit of 1000. For all the pokemons not in this list it will use the default Min settings.


MultiProfile ConfigPaths can now be accessed via the settings context
`ctx.LogicSettings.ProfilePath`
`ctx.LogicSettings.ConfigPath`
This is needed for all upcoming features like pokemon.csv output and other file related things