### PR TITLE
Fix mono/Linux compatibility

### DIFF
--- a/PoGo.NecroBot.CLI/ConsoleLogger.cs
+++ b/PoGo.NecroBot.CLI/ConsoleLogger.cs
@@ -34,7 +34,7 @@ namespace PoGo.NecroBot.CLI
         public void Write(string message, LogLevel level = LogLevel.Info, ConsoleColor color = ConsoleColor.Black)
         {
             //Remember to change to a font that supports your language, otherwise it'll still show as ???
-            Console.OutputEncoding = Encoding.Unicode;
+            Console.OutputEncoding = Encoding.UTF8;
             if (level > _maxLogLevel)
                 return;
 

--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -15,9 +15,9 @@ namespace PoGo.NecroBot.Logic.Common
         public static Translations Load(string translationsLanguageCode)
         {
             ProfilePath = Directory.GetCurrentDirectory();
-            ConfigPath = ProfilePath + "\\config\\translations";
+            ConfigPath = Path.Combine(ProfilePath, "config", "translations");
 
-            var fullPath = ConfigPath + "\\translation." + translationsLanguageCode + ".json";
+            var fullPath = Path.Combine(ConfigPath, "translation." + translationsLanguageCode + ".json");
 
             Translations translations = null;
             if (File.Exists(fullPath))
@@ -35,7 +35,7 @@ namespace PoGo.NecroBot.Logic.Common
             else
             {
                 translations = new Translations();
-                translations.Save(ConfigPath + "\\translation.en.json");
+                translations.Save(Path.Combine(ConfigPath, "translation.en.json"));
             }
             return translations;
         }

--- a/PoGo.NecroBot.Logic/Navigation.cs
+++ b/PoGo.NecroBot.Logic/Navigation.cs
@@ -3,7 +3,7 @@
 #region using directives
 
 using System;
-using System.Device.Location;
+using GeoCoordinatePortable;
 using System.Threading.Tasks;
 using PoGo.NecroBot.Logic.Utils;
 using PokemonGo.RocketAPI;

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -30,18 +30,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Google.Protobuf, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Protobuf.3.0.0-beta4\lib\net45\Google.Protobuf.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="POGOProtos, Version=1.3.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\POGOProtos.1.3.0\lib\net45\POGOProtos.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -53,6 +41,18 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="Google.Protobuf, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604">
+      <HintPath>..\packages\Google.Protobuf.3.0.0-beta4\lib\net45\Google.Protobuf.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="POGOProtos, Version=1.3.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\POGOProtos.1.3.0\lib\net45\POGOProtos.dll</HintPath>
+    </Reference>
+    <Reference Include="GeoCoordinatePortable">
+      <HintPath>..\packages\GeoCoordinate.1.1.0\lib\portable-net45+wp80+win+wpa81\GeoCoordinatePortable.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\Translations.cs" />
@@ -120,7 +120,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FeroxRev\PokemonGo.RocketAPI\PokemonGo.RocketAPI.csproj">
-      <Project>{05d2da44-1b8e-4cf7-94ed-4d52451cd095}</Project>
+      <Project>{05D2DA44-1B8E-4CF7-94ED-4D52451CD095}</Project>
       <Name>PokemonGo.RocketAPI</Name>
     </ProjectReference>
   </ItemGroup>

--- a/PoGo.NecroBot.Logic/State/VersionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/VersionCheckState.cs
@@ -50,19 +50,24 @@ namespace PoGo.NecroBot.Logic.State
             }
 
             machine.Fire(new UpdateEvent {Message = "Downloading and apply Update...."});
+
             const string zipName = "Release.zip";
             var downloadLink = _remoteReleaseUrl + zipName;
-            var baseDir = new DirectoryInfo(Directory.GetCurrentDirectory());
-            var downloadFilePath = baseDir + "\\" + zipName;
-            var tempPath = baseDir + "\\tmp";
-            var extractedDir = tempPath + "\\Release";
-            var destinationDir = baseDir + "\\";
+            var baseDir = Directory.GetCurrentDirectory();
+            var downloadFilePath = Path.Combine(baseDir, zipName);
+            var tempPath = Path.Combine(baseDir, "tmp");
+            var extractedDir = Path.Combine(tempPath, "Release");
+            var destinationDir = baseDir + Path.DirectorySeparatorChar;
+
             if (!DownloadFile(downloadLink, downloadFilePath)) return new LoginState();
-            machine.Fire(new UpdateEvent { Message = "Finished downloading newest Release..." });
+                machine.Fire(new UpdateEvent { Message = "Finished downloading newest Release..." });
+
             if (!UnpackFile(downloadFilePath, tempPath)) return new LoginState();
-            machine.Fire(new UpdateEvent { Message = "Finished unpacking files..." });
+                machine.Fire(new UpdateEvent { Message = "Finished unpacking files..." });
+
             if (!MoveAllFiles(extractedDir, destinationDir)) return new LoginState();
-            machine.Fire(new UpdateEvent {Message = "Update finished, you can close this window now."});
+                machine.Fire(new UpdateEvent {Message = "Update finished, you can close this window now."});
+
             Process.Start(Assembly.GetEntryAssembly().Location);
             Environment.Exit(-1);
             return null;
@@ -70,20 +75,29 @@ namespace PoGo.NecroBot.Logic.State
 
         public static void CleanupOldFiles()
         {
-            if (Directory.Exists(Directory.GetCurrentDirectory() + "\\tmp\\"))
-                Directory.Delete(Directory.GetCurrentDirectory() + "\\tmp\\", true);
+            string tmpDir = Path.Combine(Directory.GetCurrentDirectory(), "tmp");
+
+            if (Directory.Exists(tmpDir))
+            {
+                Directory.Delete(tmpDir, true);
+            }
+
             var di = new DirectoryInfo(Directory.GetCurrentDirectory());
             var files = di.GetFiles("*.old");
+
             foreach (var file in files)
+            {
                 try
                 {
-                    if (file.Name.Contains("vshost")) continue;
+                    if (file.Name.Contains("vshost"))
+                        continue;
                     File.Delete(file.FullName);
                 }
                 catch (Exception e)
                 {
                     Logger.Write(e.ToString());
                 }
+            }
         }
 
         public static bool DownloadFile(string url, string dest)

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Device.Location;
+using GeoCoordinatePortable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/PoGo.NecroBot.Logic/Utils/LocationUtils.cs
+++ b/PoGo.NecroBot.Logic/Utils/LocationUtils.cs
@@ -1,7 +1,7 @@
 ﻿#region using directives
 
 using System;
-using System.Device.Location;
+using GeoCoordinatePortable;
 
 #endregion
 

--- a/PoGo.NecroBot.Logic/packages.config
+++ b/PoGo.NecroBot.Logic/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="GeoCoordinate" version="1.1.0" targetFramework="net45" />
   <package id="Google.Protobuf" version="3.0.0-beta4" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="POGOProtos" version="1.3.0" targetFramework="net45" />


### PR DESCRIPTION
I fixed some problems which prevented the bot from running properly on mono/Linux.

Changes:

- replace `System.Device.Location.GeoCoordinate` with `GeoCoordinatePortable.GeoCoordinate` (nuget package), because `System.Device.Location` assembly ist not available on mono/Linux
- replace hard coded paths with calls to `Path.Combine()`
- change `Console.OutputEncoding` to UTF8