### PR TITLE
Fix evolution logic

### DIFF
--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -265,7 +265,10 @@ namespace PoGo.NecroBot.Logic
             //Don't evolve pokemon in gyms
             if (filter != null)
             {
-                myPokemons = myPokemons.Where(p => filter.Contains(p.PokemonId));
+                myPokemons =
+                    myPokemons.Where(
+                        p => (_logicClient.Settings.EvolveAllPokemonWithEnoughCandy && filter.Contains(p.PokemonId)) ||
+                             (_logicClient.Settings.EvolveAllPokemonAboveIv && (PokemonInfo.CalculatePokemonPerfection(p) >= _logicClient.Settings.EvolveAboveIvValue)));
             }
             var pokemons = myPokemons.ToList();
 
@@ -290,20 +293,9 @@ namespace PoGo.NecroBot.Logic
                         p => pokemonSettings.Single(x => x.PokemonId == p.PokemonId).FamilyId == settings.FamilyId)*
                     settings.CandyToEvolve;
 
-                if (_logicClient.Settings.EvolveAllPokemonAboveIv)
+                if (familyCandy.Candy - pokemonCandyNeededAlready > settings.CandyToEvolve)
                 {
-                    if (PokemonInfo.CalculatePokemonPerfection(pokemon) >= _logicClient.Settings.EvolveAboveIvValue &&
-                        familyCandy.Candy - pokemonCandyNeededAlready > settings.CandyToEvolve)
-                    {
-                        pokemonToEvolve.Add(pokemon);
-                    }
-                }
-                else
-                {
-                    if (familyCandy.Candy - pokemonCandyNeededAlready > settings.CandyToEvolve)
-                    {
-                        pokemonToEvolve.Add(pokemon);
-                    }
+                    pokemonToEvolve.Add(pokemon);
                 }
             }
 

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -263,12 +263,16 @@ namespace PoGo.NecroBot.Logic
             var myPokemons = await GetPokemons();
             myPokemons = myPokemons.Where(p => p.DeployedFortId == string.Empty).OrderByDescending(p => p.Cp);
             //Don't evolve pokemon in gyms
-            if (filter != null)
+            if (filter.Any())
             {
                 myPokemons =
                     myPokemons.Where(
                         p => (_logicClient.Settings.EvolveAllPokemonWithEnoughCandy && filter.Contains(p.PokemonId)) ||
                              (_logicClient.Settings.EvolveAllPokemonAboveIv && (PokemonInfo.CalculatePokemonPerfection(p) >= _logicClient.Settings.EvolveAboveIvValue)));
+            }
+            else if (_logicClient.Settings.EvolveAllPokemonAboveIv)
+            {
+                myPokemons = myPokemons.Where(p => PokemonInfo.CalculatePokemonPerfection(p) >= _logicClient.Settings.EvolveAboveIvValue);
             }
             var pokemons = myPokemons.ToList();
 


### PR DESCRIPTION
EvolveAllPokemonAboveIv and EvolveAllPokemonWithEnoughCandy configs share the same task yet do not properly differentiate between the two in the logic.

The logic is now as follows:
If EvolveAllPokemonWithEnoughCandy only true, then it will evolve all in PokemonsToEvolve list.
If EvolveAllPokemonAboveIv only true, then only those above the threshold will be evolved.
If both, evolves all in list and those above the threshold.

This should resolve #810 and #816.

I have also implemented #763, where an empty PokemonsToEvolve list evolves all eligible pokemon.