### PR TITLE
Add PokemonsToTransfer

### DIFF
--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -221,6 +221,11 @@ namespace PoGo.NecroBot.CLI
             PokemonId.Doduo
         };
 
+        public List<PokemonId> PokemonsToTransfer = new List<PokemonId>
+        {
+            PokemonId.Pinsir
+        };
+
         public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter = new Dictionary<PokemonId, TransferFilter>
         {
             {PokemonId.Pidgeotto, new TransferFilter(1500, 90, 1)},
@@ -360,6 +365,7 @@ namespace PoGo.NecroBot.CLI
         public ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter => _settings.ItemRecycleFilter;
         public ICollection<PokemonId> PokemonsToEvolve => _settings.PokemonsToEvolve;
         public ICollection<PokemonId> PokemonsNotToTransfer => _settings.PokemonsNotToTransfer;
+        public ICollection<PokemonId> PokemonsToTransfer => _settings.PokemonsToTransfer;
         public ICollection<PokemonId> PokemonsNotToCatch => _settings.PokemonsToIgnore;
         public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter => _settings.PokemonsTransferFilter;
     }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -59,6 +59,8 @@ namespace PoGo.NecroBot.Logic
 
         ICollection<PokemonId> PokemonsNotToTransfer { get; }
 
+        ICollection<PokemonId> PokemonsToTransfer { get; }
+
         ICollection<PokemonId> PokemonsNotToCatch { get; }
 
         Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter { get; }

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -343,5 +343,21 @@ namespace PoGo.NecroBot.Logic
                 ss.Release();
             }
         }
+
+        public async Task<IEnumerable<PokemonData>> GetPokemonToTransfer(IEnumerable<PokemonId> filter)
+        {
+            var myPokemons = await GetPokemons();
+            myPokemons = myPokemons.Where(p => p.DeployedFortId == string.Empty).
+                                    Where(p => filter.Contains(p.PokemonId)).
+                                    OrderByDescending(p => p.PokemonId);
+            // Don't transfer pokemon in gyms
+            IEnumerable<PokemonId> pokemonIds = filter as PokemonId[] ?? filter.ToArray();
+            if (pokemonIds.Any())
+            {
+                myPokemons = myPokemons.Where(p => pokemonIds.Contains(p.PokemonId));
+            }
+            var pokemonToTransfer = myPokemons.ToList();
+            return pokemonToTransfer;
+        }
     }
 }

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Tasks\FarmPokestopsTask.cs" />
     <Compile Include="Tasks\RecycleItemsTask.cs" />
     <Compile Include="Tasks\RenamePokemonTask.cs" />
+    <Compile Include="Tasks\ToTransferPokemonTask.cs" />
     <Compile Include="Tasks\TransferDuplicatePokemonTask.cs" />
     <Compile Include="Event\UseLuckyEggEvent.cs" />
     <Compile Include="State\VersionCheckState.cs" />

--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -25,7 +25,7 @@ namespace PoGo.NecroBot.Logic.State
             {
                 await RenamePokemonTask.Execute(ctx, machine);
             }
-
+            await ToTransferPokemonTask.Execute(ctx, machine);
             await RecycleItemsTask.Execute(ctx, machine);
 
             if (ctx.LogicSettings.UseEggIncubators)

--- a/PoGo.NecroBot.Logic/Tasks/CatchIncensePokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchIncensePokemonsTask.cs
@@ -55,9 +55,12 @@ namespace PoGo.NecroBot.Logic.Tasks
                     }
                     else if (encounter.Result == IncenseEncounterResponse.Types.Result.PokemonInventoryFull)
                     {
+                        machine.Fire(new WarnEvent { Message = "PokemonInventory is Full.Transferring pokemons..." });
+                        await ToTransferPokemonTask.Execute(ctx, machine);
+
                         if (ctx.LogicClient.Settings.TransferDuplicatePokemon)
                         {
-                            machine.Fire(new WarnEvent {Message = "PokemonInventory is Full.Transferring pokemons..."});
+                            machine.Fire(new WarnEvent {Message = "PokemonInventory is Full.Transferring duplicate pokemons..."});
                             await TransferDuplicatePokemonTask.Execute(ctx, machine);
                         }
                         else

--- a/PoGo.NecroBot.Logic/Tasks/CatchLurePokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchLurePokemonsTask.cs
@@ -37,9 +37,11 @@ namespace PoGo.NecroBot.Logic.Tasks
                 }
                 else if (encounter.Result == DiskEncounterResponse.Types.Result.PokemonInventoryFull)
                 {
+                    machine.Fire(new WarnEvent { Message = "PokemonInventory is Full.Transferring pokemons..." });
+                    await ToTransferPokemonTask.Execute(ctx, machine);
                     if (ctx.LogicClient.Settings.TransferDuplicatePokemon)
                     {
-                        machine.Fire(new WarnEvent {Message = "PokemonInventory is Full.Transferring pokemons..."});
+                        machine.Fire(new WarnEvent {Message = "PokemonInventory is Full.Transferring duplicate pokemons..."});
                         await TransferDuplicatePokemonTask.Execute(ctx, machine);
                     }
                     else

--- a/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
@@ -41,9 +41,12 @@ namespace PoGo.NecroBot.Logic.Tasks
                 }
                 else if (encounter.Status == EncounterResponse.Types.Status.PokemonInventoryFull)
                 {
+                    machine.Fire(new WarnEvent { Message = "PokemonInventory is Full.Transferring pokemons..." });
+                    await ToTransferPokemonTask.Execute(ctx, machine);
+
                     if (ctx.LogicClient.Settings.TransferDuplicatePokemon)
                     {
-                        machine.Fire(new WarnEvent {Message = "PokemonInventory is Full.Transferring pokemons..."});
+                        machine.Fire(new WarnEvent {Message = "PokemonInventory is Full.Transferring duplicate pokemons..."});
                         await TransferDuplicatePokemonTask.Execute(ctx, machine);
                     }
                     else

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -102,6 +102,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                             {
                                 await TransferDuplicatePokemonTask.Execute(ctx, machine);
                             }
+                            await ToTransferPokemonTask.Execute(ctx, machine);
 
                             if (ctx.LogicSettings.RenameAboveIv)
                             {

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -148,6 +148,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     {
                         await TransferDuplicatePokemonTask.Execute(ctx, machine);
                     }
+                    await ToTransferPokemonTask.Execute(ctx, machine);
                     if (ctx.LogicSettings.RenameAboveIv)
                     {
                         await RenamePokemonTask.Execute(ctx, machine);

--- a/PoGo.NecroBot.Logic/Tasks/ToTransferPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/ToTransferPokemonTask.cs
@@ -1,0 +1,52 @@
+﻿#region using directives
+
+using System.Linq;
+using System.Threading.Tasks;
+using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.PoGoUtils;
+using PoGo.NecroBot.Logic.State;
+
+#endregion
+
+namespace PoGo.NecroBot.Logic.Tasks
+{
+    /// <summary>
+    /// This method will transfer all the pokemon no matter IV or CP given a ConfigPokemonsToTransfer.ini
+    /// </summary>
+    /// <returns></returns>
+    public class ToTransferPokemonTask
+    {
+        public static async Task Execute(Context ctx, StateMachine machine)
+        {
+            var toTransferPokemons = await ctx.Inventory.GetPokemonToTransfer(ctx.LogicSettings.PokemonsToTransfer);
+
+            var pokemonSettings = await ctx.Inventory.GetPokemonSettings();
+            var pokemonFamilies = await ctx.Inventory.GetPokemonFamilies();
+
+            foreach (var toTransferPokemon in toTransferPokemons)
+            {
+                await ctx.Client.Inventory.TransferPokemon(toTransferPokemon.Id);
+                await ctx.Inventory.DeletePokemonFromInvById(toTransferPokemon.Id);
+
+                var setting = pokemonSettings.Single(q => q.PokemonId == toTransferPokemon.PokemonId);
+                var family = pokemonFamilies.First(q => q.FamilyId == setting.FamilyId);
+
+                var bestPokemonOfType = (ctx.LogicSettings.PrioritizeIvOverCp
+                    ? await ctx.Inventory.GetHighestPokemonOfTypeByIv(toTransferPokemon)
+                    : await ctx.Inventory.GetHighestPokemonOfTypeByCp(toTransferPokemon)) ?? toTransferPokemon;
+                
+                family.Candy++;
+
+                machine.Fire(new TransferPokemonEvent
+                {
+                    Id = toTransferPokemon.PokemonId,
+                    Perfection = PokemonInfo.CalculatePokemonPerfection(toTransferPokemon),
+                    Cp = toTransferPokemon.Cp,
+                    BestCp = bestPokemonOfType.Cp,
+                    BestPerfection = PokemonInfo.CalculatePokemonPerfection(bestPokemonOfType),
+                    FamilyCandies = family.Candy
+                });
+            }
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -57,6 +57,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 {
                     await TransferDuplicatePokemonTask.Execute(ctx, machine);
                 }
+                await ToTransferPokemonTask.Execute(ctx, machine);
             }
         }
 


### PR DESCRIPTION
Add a setting to force pokemon transfer using a PokemonsToTransfer setting.
This feature permit to still catch all Pokemons wich obviously is good for Candies and XP.
Still you want to transfer Pinsir, Rattata, Pidgey even if they are above both CP and IV.

This feature through a PokemonsToTransfer list permits to catch pokemon and later on transfer them keeping the current StateMachine Logic.

related issues:
- https://github.com/NecronomiconCoding/NecroBot/issues/975
- https://github.com/NecronomiconCoding/NecroBot/issues/930
- https://github.com/NecronomiconCoding/NecroBot/issues/742
- https://github.com/NecronomiconCoding/NecroBot/issues/613