### PR TITLE
Clean profile/translation path logic

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -32,11 +32,12 @@ namespace PoGo.NecroBot.CLI
 
             if (settings == null)
             {
-                Logger.Write("This is your first start and the bot will use the default config!", LogLevel.Warning);
-                Logger.Write("Continue? (y/n)", LogLevel.Warning);
+                Logger.Write("First start conditions detected! A default config.json has been generated for you.", LogLevel.Warning);
+                Logger.Write("This warning will not appear again. Continue with default settings? (y/n)", LogLevel.Warning);
 
                 if (!Console.ReadLine().ToUpper().Equals("Y"))
                     return;
+
                 settings = GlobalSettings.Load(subPath);
             }
 

--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using PoGo.NecroBot.Logic.State;
 
 #endregion
 
@@ -12,9 +13,6 @@ namespace PoGo.NecroBot.Logic.Common
 {
     public class Translations
     {
-        public static string ProfilePath;
-        public static string ConfigPath;
-
         //Default Translations (ENGLISH)
         public List<KeyValuePair<TranslationString, string>> TranslationStrings = new List
             <KeyValuePair<TranslationString, string>>
@@ -138,12 +136,11 @@ namespace PoGo.NecroBot.Logic.Common
             return translation != default(string) ? translation : $"Translation for {translationString} is missing";
         }
 
-        public static Translations Load(string translationsLanguageCode)
+        public static Translations Load(ILogicSettings logicSettings)
         {
-            ProfilePath = Directory.GetCurrentDirectory();
-            ConfigPath = Path.Combine(ProfilePath, "config", "translations");
-
-            var fullPath = Path.Combine(ConfigPath, "translation." + translationsLanguageCode + ".json");
+            string translationsLanguageCode = logicSettings.TranslationLanguageCode;
+            var translationPath = Path.Combine(logicSettings.GeneralConfigPath, "translations");
+            var fullPath = Path.Combine(translationPath, "translation." + translationsLanguageCode + ".json");
 
             Translations translations;
             if (File.Exists(fullPath))
@@ -161,7 +158,7 @@ namespace PoGo.NecroBot.Logic.Common
             else
             {
                 translations = new Translations();
-                translations.Save(Path.Combine(ConfigPath, "translation.en.json"));
+                translations.Save(Path.Combine(translationPath, "translation.en.json"));
             }
             return translations;
         }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -51,7 +51,8 @@ namespace PoGo.NecroBot.Logic
         int AmountOfPokemonToDisplayOnStart { get; }
         string TranslationLanguageCode { get; }
         string ProfilePath { get; }
-        string ConfigPath { get; }
+        string ProfileConfigPath { get; }
+        string GeneralConfigPath { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -99,8 +99,11 @@ namespace PoGo.NecroBot.CLI
 
         [JsonIgnore] internal AuthSettings Auth = new AuthSettings();
 
+        [JsonIgnore] public string ProfilePath;
+        [JsonIgnore] public string ProfileConfigPath;
+        [JsonIgnore] public string GeneralConfigPath;
+
         public bool AutoUpdate = true;
-        public string ConfigPath;
         public double DefaultAltitude = 10;
         public double DefaultLatitude = 40.785091;
         public double DefaultLongitude = -73.968285;
@@ -231,7 +234,6 @@ namespace PoGo.NecroBot.CLI
         };
 
         public bool PrioritizeIvOverCp = false;
-        public string ProfilePath;
         public bool RenameAboveIv = false;
         public bool TransferDuplicatePokemon = true;
         public string TranslationLanguageCode = "en";
@@ -248,13 +250,13 @@ namespace PoGo.NecroBot.CLI
         {
             GlobalSettings settings;
             var profilePath = Path.Combine(Directory.GetCurrentDirectory(), path);
-            var configPath = Path.Combine(profilePath, "config");
-            var fullPath = Path.Combine(configPath, "config.json");
+            var profileConfigPath = Path.Combine(profilePath, "config");
+            var configFile = Path.Combine(profileConfigPath, "config.json");
 
-            if (File.Exists(fullPath))
+            if (File.Exists(configFile))
             {
                 //if the file exists, load the settings
-                var input = File.ReadAllText(fullPath);
+                var input = File.ReadAllText(configFile);
 
                 var jsonSettings = new JsonSerializerSettings();
                 jsonSettings.Converters.Add(new StringEnumConverter {CamelCaseText = true});
@@ -273,16 +275,18 @@ namespace PoGo.NecroBot.CLI
                 settings.WebSocketPort = 14251;
             }
             settings.ProfilePath = profilePath;
-            settings.ConfigPath = configPath;
 
-            if (!File.Exists(fullPath))
-            {
-                settings.Save(fullPath);
-                return null;
-            }
-            
+            settings.ProfileConfigPath = profileConfigPath;
+            settings.GeneralConfigPath = Directory.GetCurrentDirectory();
 
-            settings.Auth.Load(Path.Combine(configPath, "auth.json"));
+
+            var firstRun = !File.Exists(configFile);
+
+            settings.Save(configFile);
+
+            if (firstRun) return null;
+
+            settings.Auth.Load(Path.Combine(profileConfigPath, "auth.json"));
 
             return settings;
         }
@@ -341,7 +345,8 @@ namespace PoGo.NecroBot.CLI
         }
 
         public string ProfilePath => _settings.ProfilePath;
-        public string ConfigPath => _settings.ConfigPath;
+        public string ProfileConfigPath => _settings.ProfileConfigPath;
+        public string GeneralConfigPath => _settings.GeneralConfigPath;
         public bool AutoUpdate => _settings.AutoUpdate;
         public float KeepMinIvPercentage => _settings.KeepMinIvPercentage;
         public int KeepMinCp => _settings.KeepMinCp;

--- a/PoGo.NecroBot.Logic/State/Session.cs
+++ b/PoGo.NecroBot.Logic/State/Session.cs
@@ -30,7 +30,7 @@ namespace PoGo.NecroBot.Logic.State
             Settings = settings;
             LogicSettings = logicSettings;
             EventDispatcher = new EventDispatcher();
-            Translations = Translations.Load(logicSettings.TranslationLanguageCode);
+            Translations = Translations.Load(logicSettings);
             Reset(settings, LogicSettings);
         }
 


### PR DESCRIPTION
Path variables re-structured as:
```
ProfilePath = \Release\Profile\
ProfileConfigPath = \Release\Profile\Config\
GeneralConfigPath = \Release\Config
```
Path variables available in ILogicSettings
Add [JsonIgnores] to path variables

Bugfix: config.json should be saved during first run case
Make first run messages more explicit