### PR TITLE
Settings rearrange & added config paths

### DIFF
--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using PoGo.NecroBot.Logic.State;
 
 #endregion
 
@@ -235,13 +236,11 @@ namespace PoGo.NecroBot.Logic.Common
             var translation = TranslationStrings.FirstOrDefault(t => t.Key.Equals(translationString)).Value;
             return translation != default(string) ? translation : $"Translation for {translationString} is missing";
         }
-
-        public static Translation Load(string translationsLanguageCode)
+        public static Translation Load(ILogicSettings logicSettings)
         {
-            string profilePath = Directory.GetCurrentDirectory();
-            string configPath = Path.Combine(profilePath, "config", "translations");
-
-            var fullPath = Path.Combine(configPath, "translation." + translationsLanguageCode + ".json");
+            string translationsLanguageCode = logicSettings.TranslationLanguageCode;
+            var translationPath = Path.Combine(logicSettings.GeneralConfigPath, "translations");
+            var fullPath = Path.Combine(translationPath, "translation." + translationsLanguageCode + ".json");
 
             Translation translations;
             if (File.Exists(fullPath))
@@ -259,7 +258,7 @@ namespace PoGo.NecroBot.Logic.Common
             else
             {
                 translations = new Translation();
-                translations.Save(Path.Combine(configPath, "translation.en.json"));
+                translations.Save(Path.Combine(translationPath, "translation.en.json"));
             }
             return translations;
         }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -53,7 +53,8 @@ namespace PoGo.NecroBot.Logic
         int AmountOfPokemonToDisplayOnStart { get; }
         string TranslationLanguageCode { get; }
         string ProfilePath { get; }
-        string ConfigPath { get; }
+        string ProfileConfigPath { get; }
+        string GeneralConfigPath { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -100,9 +100,11 @@ namespace PoGo.NecroBot.CLI
         public int AmountOfPokemonToDisplayOnStart = 10;
 
         [JsonIgnore] internal AuthSettings Auth = new AuthSettings();
+        [JsonIgnore] public string ProfilePath;
+        [JsonIgnore] public string ProfileConfigPath;
+        [JsonIgnore] public string GeneralConfigPath;
 
         public bool AutoUpdate = true;
-        public string ConfigPath;
         public double DefaultAltitude = 10;
         public double DefaultLatitude = 40.785091;
         public double DefaultLongitude = -73.968285;
@@ -110,8 +112,25 @@ namespace PoGo.NecroBot.CLI
         public float EvolveAboveIvValue = 90;
         public bool EvolveAllPokemonAboveIv = false;
         public bool EvolveAllPokemonWithEnoughCandy = true;
+        public int UseLuckyEggsMinPokemonAmount = 30;
+        public bool UseLuckyEggsWhileEvolving = false;
+        public bool UseEggIncubators = true;
         public bool DumpPokemonStats = false;
         public string GpxFile = "GPXPath.GPX";
+        public bool UseGpxPathing = false;
+        public double WalkingSpeedInKilometerPerHour = 15.0;
+        public int MaxTravelDistanceInMeters = 1000;
+        public int KeepMinCp = 1250;
+        public int KeepMinDuplicatePokemon = 1;
+        public float KeepMinIvPercentage = 95;
+        public bool KeepPokemonsThatCanEvolve = false;
+        public bool PrioritizeIvOverCp = true;
+        public bool RenameAboveIv = true;
+        public bool TransferDuplicatePokemon = true;
+        public string TranslationLanguageCode = "en";
+        public bool UsePokemonToNotCatchFilter = false;
+        public int WebSocketPort = 14251;
+        public bool StartupWelcomeDelay = true;
 
         public List<KeyValuePair<ItemId, int>> ItemRecycleFilter = new List<KeyValuePair<ItemId, int>>
         {
@@ -147,14 +166,9 @@ namespace PoGo.NecroBot.CLI
             new KeyValuePair<ItemId, int>(ItemId.ItemItemStorageUpgrade, 100)
         };
 
-        public int KeepMinCp = 1250;
-        public int KeepMinDuplicatePokemon = 1;
-        public float KeepMinIvPercentage = 95;
-        public bool KeepPokemonsThatCanEvolve = false;
-        public int MaxTravelDistanceInMeters = 1000;
-
         public List<PokemonId> PokemonsNotToTransfer = new List<PokemonId>
         {
+            PokemonId.Aerodactyl,
             PokemonId.Venusaur,
             PokemonId.Charizard,
             PokemonId.Blastoise,
@@ -243,33 +257,19 @@ namespace PoGo.NecroBot.CLI
             {PokemonId.Eevee, new TransferFilter(600, 90, 2)},
             {PokemonId.Mew, new TransferFilter(0, 0, 10)}
         };
-
-        public bool PrioritizeIvOverCp = true;
-        public string ProfilePath;
-        public bool RenameAboveIv = true;
-        public bool TransferDuplicatePokemon = true;
-        public string TranslationLanguageCode = "en";
-        public bool UseEggIncubators = true;
-        public bool UseGpxPathing = false;
-        public int UseLuckyEggsMinPokemonAmount = 30;
-        public bool UseLuckyEggsWhileEvolving = false;
-        public bool UsePokemonToNotCatchFilter = false;
-        public double WalkingSpeedInKilometerPerHour = 15.0;
-        public int WebSocketPort = 14251;
         public static GlobalSettings Default => new GlobalSettings();
-        public bool StartupWelcomeDelay = true;
 
         public static GlobalSettings Load(string path)
         {
             GlobalSettings settings;
             var profilePath = Path.Combine(Directory.GetCurrentDirectory(), path);
-            var configPath = Path.Combine(profilePath, "config");
-            var fullPath = Path.Combine(configPath, "config.json");
+            var profileConfigPath = Path.Combine(profilePath, "config");
+            var configFile = Path.Combine(profileConfigPath, "config.json");
 
-            if (File.Exists(fullPath))
+            if (File.Exists(configFile))
             {
                 //if the file exists, load the settings
-                var input = File.ReadAllText(fullPath);
+                var input = File.ReadAllText(configFile);
 
                 var jsonSettings = new JsonSerializerSettings();
                 jsonSettings.Converters.Add(new StringEnumConverter {CamelCaseText = true});
@@ -289,17 +289,16 @@ namespace PoGo.NecroBot.CLI
             }
 
             settings.ProfilePath = profilePath;
-            settings.ConfigPath = configPath;
+            settings.ProfileConfigPath = profileConfigPath;
+            settings.GeneralConfigPath = Path.Combine(Directory.GetCurrentDirectory(), "config");
 
-            if (!File.Exists(fullPath))
-            {
-                settings.Save(fullPath);
-                return null;
-            }
+            var firstRun = !File.Exists(configFile);
 
-            settings.Save(fullPath);
+            settings.Save(configFile);
 
-            settings.Auth.Load(Path.Combine(configPath, "auth.json"));
+            if (firstRun) return null;
+
+            settings.Auth.Load(Path.Combine(profileConfigPath, "auth.json"));
 
             return settings;
         }
@@ -456,7 +455,8 @@ namespace PoGo.NecroBot.CLI
         }
 
         public string ProfilePath => _settings.ProfilePath;
-        public string ConfigPath => _settings.ConfigPath;
+        public string ProfileConfigPath => _settings.ProfileConfigPath;
+        public string GeneralConfigPath => _settings.GeneralConfigPath;
         public bool AutoUpdate => _settings.AutoUpdate;
         public float KeepMinIvPercentage => _settings.KeepMinIvPercentage;
         public int KeepMinCp => _settings.KeepMinCp;

--- a/PoGo.NecroBot.Logic/State/Session.cs
+++ b/PoGo.NecroBot.Logic/State/Session.cs
@@ -30,7 +30,7 @@ namespace PoGo.NecroBot.Logic.State
             Settings = settings;
             LogicSettings = logicSettings;
             EventDispatcher = new EventDispatcher();
-            Translation = Common.Translation.Load(logicSettings.TranslationLanguageCode);
+            Translation = Common.Translation.Load(logicSettings);
             Reset(settings, LogicSettings);
         }
 


### PR DESCRIPTION
Rearranged Settings for better overview in the config.json
Fixed conflicts from
https://github.com/NecronomiconCoding/NecroBot/pull/1083
Worked this out together with Ilses so he should be fine with it. Credits to him for most of the code.

Config paths should now be access via
`ctx.LogicSettings.ProfilePath` _\Release\Profile\_
`ctx.LogicSettings.ProfileConfigPath` _\Release\Profile\Config\_
`ctx.LogicSettings.GeneralConfigPath` _\Release\Config\_