### PR TITLE
Feature/global delay between actions

### DIFF
--- a/PoGo.NecroBot.CLI/Settings.cs
+++ b/PoGo.NecroBot.CLI/Settings.cs
@@ -152,6 +152,7 @@ namespace PoGo.NecroBot.CLI
         public double DefaultLatitude = 52.379189;
         public double DefaultLongitude = 4.899431;
         public int DelayBetweenPokemonCatch = 2000;
+        public int DelayBetweenPlayerActions = 0;
         public float EvolveAboveIvValue = 95;
         public bool EvolveAllPokemonAboveIv = false;
         public bool EvolveAllPokemonWithEnoughCandy = false;
@@ -281,6 +282,7 @@ namespace PoGo.NecroBot.CLI
         public bool KeepPokemonsThatCanEvolve => _settings.KeepPokemonsThatCanEvolve;
         public bool TransferDuplicatePokemon => _settings.TransferDuplicatePokemon;
         public int DelayBetweenPokemonCatch => _settings.DelayBetweenPokemonCatch;
+        public int DelayBetweenPlayerActions => _settings.DelayBetweenPlayerActions;
         public bool UsePokemonToNotCatchFilter => _settings.UsePokemonToNotCatchFilter;
         public int KeepMinDuplicatePokemon => _settings.KeepMinDuplicatePokemon;
         public bool PrioritizeIvOverCp => _settings.PrioritizeIvOverCp;

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -17,6 +17,7 @@ namespace PoGo.NecroBot.Logic
         bool KeepPokemonsThatCanEvolve { get; }
         bool TransferDuplicatePokemon { get; }
         int DelayBetweenPokemonCatch { get; }
+        int DelayBetweenPlayerActions { get; }
         bool UsePokemonToNotCatchFilter { get; }
         int KeepMinDuplicatePokemon { get; }
         bool PrioritizeIvOverCp { get; }

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -94,6 +94,7 @@
     <Compile Include="State\VersionCheckState.cs" />
     <Compile Include="Event\WarnEvent.cs" />
     <Compile Include="Tasks\UseNearbyPokestopsTask.cs" />
+    <Compile Include="Utils\DelayingUtils.cs" />
     <Compile Include="Utils\GPXReader.cs" />
     <Compile Include="Logging\ILogger.cs" />
     <Compile Include="Utils\JitterUtils.cs" />

--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -4,6 +4,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.Logging;
 using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Utils;
@@ -132,7 +133,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                 machine.Fire(evt);
 
                 attemptCounter++;
-                Thread.Sleep(2000);
+
+                DelayingUtils.Delay(ctx.LogicSettings.DelayBetweenPlayerActions, 2000);
             } while (caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchMissed ||
                      caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchEscape);
         }

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -86,7 +86,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                                 var refreshCachedInventory = ctx.Inventory.RefreshCachedInventory();
                             }
 
-                            Thread.Sleep(1000);
+                            DelayingUtils.Delay(ctx.LogicSettings.DelayBetweenPlayerActions, 1000);
 
                             RecycleItemsTask.Execute(ctx, machine);
 

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -94,8 +94,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                     });
                 }
 
+                DelayingUtils.Delay(ctx.LogicSettings.DelayBetweenPlayerActions, 1000);
 
-                Thread.Sleep(1000);
                 if (++stopsHit%5 == 0) //TODO: OR item/pokemon bag is full
                 {
                     stopsHit = 0;

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -2,7 +2,9 @@
 
 using System.Threading;
 using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.Logging;
 using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Utils;
 
 #endregion
 
@@ -20,7 +22,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 machine.Fire(new ItemRecycledEvent {Id = item.ItemId, Count = item.Count});
 
-                Thread.Sleep(500);
+                DelayingUtils.Delay(ctx.LogicSettings.DelayBetweenPlayerActions, 500);              
             }
 
             ctx.Inventory.RefreshCachedInventory().Wait();

--- a/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
@@ -2,10 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.Logging;
 using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Utils;
 
 namespace PoGo.NecroBot.Logic.Tasks
 {
@@ -33,6 +36,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                     {
                         Message = $"Pokemon {pokemon.PokemonId} ({pokemon.Id}) renamed from {pokemon.Nickname} to {newNickname}."
                     });
+
+                    DelayingUtils.Delay(ctx.LogicSettings.DelayBetweenPlayerActions, 0);
                 }
                 else if (newNickname == pokemon.Nickname && !ctx.LogicSettings.RenameAboveIv)
                 {
@@ -42,6 +47,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                     {
                         Message = $"Pokemon {pokemon.PokemonId} ({pokemon.Id}) renamed from {pokemon.Nickname} to {pokemon.PokemonId}."
                     });
+
+                    DelayingUtils.Delay(ctx.LogicSettings.DelayBetweenPlayerActions, 0);
                 }
             }
 

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -1,9 +1,12 @@
 ﻿#region using directives
 
 using System.Linq;
+using System.Threading;
 using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.Logging;
 using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Utils;
 
 #endregion
 
@@ -52,6 +55,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                     BestPerfection = PokemonInfo.CalculatePokemonPerfection(bestPokemonOfType),
                     FamilyCandies = family.Candy
                 });
+
+                DelayingUtils.Delay(ctx.LogicSettings.DelayBetweenPlayerActions, 0);
             }
         }
     }

--- a/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseNearbyPokestopsTask.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.Logging;
 using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Utils;
 using PokemonGo.RocketAPI.Extensions;
@@ -45,7 +46,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     });
                 }
 
-                Thread.Sleep(1000);
+                DelayingUtils.Delay(ctx.LogicSettings.DelayBetweenPlayerActions, 1000);
 
                 RecycleItemsTask.Execute(ctx, machine);
 

--- a/PoGo.NecroBot.Logic/Utils/DelayingUtils.cs
+++ b/PoGo.NecroBot.Logic/Utils/DelayingUtils.cs
@@ -6,16 +6,23 @@ namespace PoGo.NecroBot.Logic.Utils
 {
     public static class DelayingUtils
     {
+        private static readonly Random RandomDevice = new Random();
+
         public static void Delay(int delay, int defdelay)
         {
             if (delay > 0)
             {
-                Logger.Write($"Waiting (inside of DelayingUtils) for {delay / 1000} seconds using global delay");
-                Thread.Sleep(delay);
+                float randomFactor = 0.3f;
+                int randomMin = (int) delay * (1 - randomFactor);
+                int randomMax = (int) delay * (1 + randomFactor);
+                int randomizedDelay = RandomDevice.Next(randomMin, randomMax);
+               
+                Logger.Write($"Waiting (inside of DelayingUtils) for {randomizedDelay / 1000:0.#} seconds using global delay");
+                Thread.Sleep(randomizedDelay);
             }
             else if (defdelay > 0)
             {
-                Logger.Write($"Waiting (inside of DelayingUtils) for {defdelay / 1000} seconds using default delay");
+                Logger.Write($"Waiting (inside of DelayingUtils) for {defdelay / 1000:0.#} seconds using default delay");
                 Thread.Sleep(defdelay);
             }
         }

--- a/PoGo.NecroBot.Logic/Utils/DelayingUtils.cs
+++ b/PoGo.NecroBot.Logic/Utils/DelayingUtils.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading;
+using PoGo.NecroBot.Logic.Logging;
+
+namespace PoGo.NecroBot.Logic.Utils
+{
+    public static class DelayingUtils
+    {
+        public static void Delay(int delay, int defdelay)
+        {
+            if (delay > 0)
+            {
+                Logger.Write($"Waiting (inside of DelayingUtils) for {delay / 1000} seconds using global delay");
+                Thread.Sleep(delay);
+            }
+            else if (defdelay > 0)
+            {
+                Logger.Write($"Waiting (inside of DelayingUtils) for {defdelay / 1000} seconds using default delay");
+                Thread.Sleep(defdelay);
+            }
+        }
+    }
+}


### PR DESCRIPTION
FEATURE: randomized delay between each action

DelayBetweenPlayerActions (Value)
Delay in miliseconds between any actions (such as attempt to catch a
pokemon, evolving a pokemon, farming a pokestop, recycling an itep etc).
This value is randomized between + and - 30% of given value after each
action. If set to 0, default delays are applied (for some of the
actions).