### PR TITLE
FEATURE: randomized delay between each action

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -38,6 +38,7 @@ namespace PoGo.NecroBot.Logic
         bool TransferDuplicatePokemon { get; }
         bool UseEggIncubators { get; }
         int DelayBetweenPokemonCatch { get; }
+        int DelayBetweenPlayerActions { get; }
         bool UsePokemonToNotCatchFilter { get; }
         int KeepMinDuplicatePokemon { get; }
         bool PrioritizeIvOverCp { get; }

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Event\WarnEvent.cs" />
     <Compile Include="Tasks\UseIncubatorsTask.cs" />
     <Compile Include="Tasks\UseNearbyPokestopsTask.cs" />
+    <Compile Include="Utils\DelayingUtils.cs" />
     <Compile Include="Utils\EggWalker.cs" />
     <Compile Include="Utils\GPXReader.cs" />
     <Compile Include="Logging\ILogger.cs" />

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -85,6 +85,7 @@ namespace PoGo.NecroBot.CLI
         public double DefaultLatitude = 40.785091;
         public double DefaultLongitude = -73.968285;
         public int DelayBetweenPokemonCatch = 2000;
+        public int DelayBetweenPlayerActions = 5000;
         public float EvolveAboveIvValue = 90;
         public bool EvolveAllPokemonAboveIv = false;
         public bool EvolveAllPokemonWithEnoughCandy = true;

--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -133,7 +133,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                 session.EventDispatcher.Send(evt);
 
                 attemptCounter++;
-                await Task.Delay(2000);
+                
+                DelayingUtils.Delay(session.LogicSettings.DelayBetweenPokemonCatch, 2000);
             } while (caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchMissed ||
                      caughtPokemonResponse.Status == CatchPokemonResponse.Types.CatchStatus.CatchEscape);
         }

--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using PoGo.NecroBot.Logic.Event;
 using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Utils;
 using PokemonGo.RocketAPI;
 using POGOProtos.Inventory.Item;
 
@@ -64,7 +65,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             await session.Client.Inventory.UseItemXpBoost();
             await session.Inventory.RefreshCachedInventory();
             session.EventDispatcher.Send(new UseLuckyEggEvent {Count = luckyEgg.Count});
-            await Task.Delay(2000);
+            DelayingUtils.Delay(session.LogicSettings.DelayBetweenPokemonCatch, 2000);
         }
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -119,8 +119,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                                 Max = retryNumber - zeroCheck
                             });
 
-                            Random random = new Random();
-                            await Task.Delay(200 + random.Next(0, 200));  //Randomized pause
+                            DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 400);
                         }
                     } else {
                         session.EventDispatcher.Send(new FortUsedEvent

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -3,6 +3,7 @@
 using System.Threading.Tasks;
 using PoGo.NecroBot.Logic.Event;
 using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Utils;
 
 #endregion
 
@@ -20,7 +21,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 session.EventDispatcher.Send(new ItemRecycledEvent {Id = item.ItemId, Count = item.Count});
 
-                await Task.Delay(500);
+                DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
             }
 
             await session.Inventory.RefreshCachedInventory();

--- a/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using PoGo.NecroBot.Logic.Event;
 using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Utils;
 
 #endregion
 
@@ -36,6 +37,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                     {
                         Message = session.Translation.GetTranslation(Common.TranslationString.PokemonRename, pokemon.PokemonId, pokemon.Id, pokemon.Nickname, newNickname)
                     });
+
+                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
                 }
                 else if (newNickname == pokemon.Nickname && !session.LogicSettings.RenameAboveIv)
                 {
@@ -45,6 +48,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                     {
                         Message = session.Translation.GetTranslation(Common.TranslationString.PokemonRename, pokemon.PokemonId, pokemon.Id, pokemon.Nickname, pokemon.PokemonId)
                     });
+
+                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
                 }
             }
         }

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using PoGo.NecroBot.Logic.Event;
 using PoGo.NecroBot.Logic.PoGoUtils;
 using PoGo.NecroBot.Logic.State;
+using PoGo.NecroBot.Logic.Utils;
 
 #endregion
 
@@ -53,6 +54,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                     BestPerfection = PokemonInfo.CalculatePokemonPerfection(bestPokemonOfType),
                     FamilyCandies = family.Candy
                 });
+
+                DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
             }
         }
     }

--- a/PoGo.NecroBot.Logic/Utils/DelayingUtils.cs
+++ b/PoGo.NecroBot.Logic/Utils/DelayingUtils.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace PoGo.NecroBot.Logic.Utils
+{
+    public static class DelayingUtils
+    {
+        private static readonly Random RandomDevice = new Random();
+
+        public static async void Delay(int delay, int defdelay)
+        {
+            if (delay > 0)
+            {
+                float randomFactor = 0.3f;
+                int randomMin = delay * (1 - randomFactor);
+                int randomMax = delay * (1 + randomFactor);
+                int randomizedDelay = RandomDevice.Next(randomMin, randomMax);
+
+                await Task.Delay(randomizedDelay);
+            }
+            else if (defdelay > 0)
+            {
+                await Task.Delay(defdelay);
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
FEATURE: randomized delay between each action

DelayBetweenPlayerActions (Value)
Delay in miliseconds between any actions (such as attempt to catch a
pokemon, evolving a pokemon, farming a pokestop, recycling an itep etc).
This value is randomized between + and - 30% of given value after each
action. If set to 0, default delays are applied (for some of the
actions).