### PR TITLE
setting up template for renaming function

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -51,6 +51,7 @@ namespace PoGo.NecroBot.Logic
         float EvolveAboveIvValue { get; }
         bool DumpPokemonStats { get; }
         bool RenameAboveIv { get; }
+        string RenameTemplate { get; }
         int AmountOfPokemonToDisplayOnStart { get; }
         string TranslationLanguageCode { get; }
         string ProfilePath { get; }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -103,6 +103,7 @@ namespace PoGo.NecroBot.CLI
         public bool KeepPokemonsThatCanEvolve = false;
         public bool PrioritizeIvOverCp = true;
         public bool RenameAboveIv = true;
+        public string RenameTemplate = "{0}_{1}";
         public bool TransferDuplicatePokemon = true;
         public string TranslationLanguageCode = "en";
         public bool UsePokemonToNotCatchFilter = false;
@@ -461,6 +462,7 @@ namespace PoGo.NecroBot.CLI
         public bool EvolveAllPokemonAboveIv => _settings.EvolveAllPokemonAboveIv;
         public float EvolveAboveIvValue => _settings.EvolveAboveIvValue;
         public bool RenameAboveIv => _settings.RenameAboveIv;
+        public string RenameTemplate => _settings.RenameTemplate;
         public int AmountOfPokemonToDisplayOnStart => _settings.AmountOfPokemonToDisplayOnStart;
         public bool DumpPokemonStats => _settings.DumpPokemonStats;
         public string TranslationLanguageCode => _settings.TranslationLanguageCode;

--- a/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
@@ -20,36 +20,26 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             foreach (var pokemon in pokemons)
             {
-                var perfection = Math.Round(PokemonInfo.CalculatePokemonPerfection(pokemon));
-                var pokemonName = pokemon.PokemonId.ToString();
-                if (pokemonName.Length > 10 - perfection.ToString(CultureInfo.InvariantCulture).Length)
+                double perfection = Math.Round(PokemonInfo.CalculatePokemonPerfection(pokemon));
+                string pokemonName = pokemon.PokemonId.ToString();
+                // iv number + templating part + pokemonName <= 12
+                int nameLength = 12 - (perfection.ToString(CultureInfo.InvariantCulture).Length + session.LogicSettings.RenameTemplate.Length - 6);
+                if (pokemonName.Length > nameLength)
                 {
-                    pokemonName = pokemonName.Substring(0, 10 - perfection.ToString(CultureInfo.InvariantCulture).Length);
+                    pokemonName = pokemonName.Substring(0, nameLength);
                 }
-                var newNickname = $"{pokemonName}_{perfection}";
+                string newNickname = String.Format(session.LogicSettings.RenameTemplate, pokemonName, perfection);
+                string oldNickname = (pokemon.Nickname.Length != 0) ? pokemon.Nickname : pokemon.PokemonId.ToString();
 
-                if (perfection > session.LogicSettings.KeepMinIvPercentage && newNickname != pokemon.Nickname &&
+                if (perfection >= session.LogicSettings.KeepMinIvPercentage && newNickname != oldNickname &&
                     session.LogicSettings.RenameAboveIv)
                 {
                     await session.Client.Inventory.NicknamePokemon(pokemon.Id, newNickname);
 
                     session.EventDispatcher.Send(new NoticeEvent
                     {
-                        Message = session.Translation.GetTranslation(Common.TranslationString.PokemonRename, pokemon.PokemonId, pokemon.Id, pokemon.Nickname, newNickname)
+                        Message = session.Translation.GetTranslation(Common.TranslationString.PokemonRename, pokemon.PokemonId, pokemon.Id, oldNickname, newNickname)
                     });
-
-                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
-                }
-                else if (newNickname == pokemon.Nickname && !session.LogicSettings.RenameAboveIv)
-                {
-                    await session.Client.Inventory.NicknamePokemon(pokemon.Id, pokemon.PokemonId.ToString());
-
-                    session.EventDispatcher.Send(new NoticeEvent
-                    {
-                        Message = session.Translation.GetTranslation(Common.TranslationString.PokemonRename, pokemon.PokemonId, pokemon.Id, pokemon.Nickname, pokemon.PokemonId)
-                    });
-
-                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 0);
                 }
             }
         }


### PR DESCRIPTION
allow to set custom template string for renaming function

example:
```json
"RenameTemplate": "{0}_{1}"
```
will output: Zubat_95

```json
"RenameTemplate": "[{1}]{0}"
```
output: [95]Zubat

{0} - Pokemon name
{1} - IV

I've spend some more time on this and figured out there was an unreachable block of code (since this task only runs if **RenameAboveIv** is true) and fixed a bug with empty name

Also now it's possible to rename Pokemons to their original name just by setting template to `"{0}"`

with IV:
![img](http://i.imgur.com/SFVSU35.png)

original:
![img](http://i.imgur.com/P5EBpiW.png)