### PR TITLE
[FIX] For Evolution Logic with LuckyEggs

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/EvolvePokemonTask.cs
@@ -24,7 +24,14 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             if (pokemonToEvolve.Any())
             {
-                if (session.LogicSettings.UseLuckyEggsWhileEvolving)
+                var inventoryContent = await session.Inventory.GetItems();
+
+                var luckyEggs = inventoryContent.Where(p => p.ItemId == ItemId.ItemLuckyEgg);
+                var luckyEgg = luckyEggs.FirstOrDefault();
+                
+                //maybe there can be a warning message as an else condition of luckyEgg checks, like; 
+                //"There is no Lucky Egg, so, your UseLuckyEggsMinPokemonAmount setting bypassed."
+                if (session.LogicSettings.UseLuckyEggsWhileEvolving && luckyEgg != null && luckyEgg.Count > 0)
                 {
                     if (pokemonToEvolve.Count >= session.LogicSettings.UseLuckyEggsMinPokemonAmount)
                     {
@@ -58,7 +65,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             var luckyEggs = inventoryContent.Where(p => p.ItemId == ItemId.ItemLuckyEgg);
             var luckyEgg = luckyEggs.FirstOrDefault();
 
-            if (luckyEgg == null || luckyEgg.Count <= 0 || _lastLuckyEggTime.AddMinutes(30).Ticks > DateTime.Now.Ticks)
+            if (_lastLuckyEggTime.AddMinutes(30).Ticks > DateTime.Now.Ticks)
                 return;
 
             _lastLuckyEggTime = DateTime.Now;


### PR DESCRIPTION
LuckyEgg existence should be checked before "UseLuckyEggsMinPokemonAmount" condition to be able to bypass it.

If there is no LuckyEgg in inventory, there is also no need to check "pokemonToEvolve.Count" value. It should just evolve the pokemon.