### PR TITLE
Improved bottleneck when run out of pokeballs

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchNearbyPokemonsTask.cs
@@ -22,6 +22,14 @@ namespace PoGo.NecroBot.Logic.Tasks
             var pokemons = await GetNearbyPokemons(session);
             foreach (var pokemon in pokemons)
             {
+                var pokeBallsCount = await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemPokeBall);
+                var greatBallsCount = await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemGreatBall);
+                var ultraBallsCount = await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemUltraBall);
+                var masterBallsCount = await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemMasterBall);
+
+                if (pokeBallsCount + greatBallsCount + ultraBallsCount + masterBallsCount == 0)
+                    return;
+                    
                 if (session.LogicSettings.UsePokemonToNotCatchFilter &&
                     session.LogicSettings.PokemonsNotToCatch.Contains(pokemon.PokemonId))
                 {


### PR DESCRIPTION
Due to the sleep in here this function can delay the walk to a pokestop up to (pokemons around you) * 3 sec. Not sure if it's worth to implement the calls. A check for EventNoPokeballs after the EncounterPokemon with a loop break might be better even though it's after the sleep.