### PR TITLE
[Feature] Configurable Pokemon Sniping

### DIFF
--- a/PoGo.NecroBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.NecroBot.CLI/ConsoleEventListener.cs
@@ -180,6 +180,11 @@ namespace PoGo.NecroBot.CLI
             Logger.Write(session.Translation.GetTranslation(TranslationString.EventNoPokeballs, evt.Count), LogLevel.Berry);
         }
 
+        public void HandleEvent(SnipeScanEvent evt, ISession session)
+        {
+            Logger.Write(session.Translation.GetTranslation(TranslationString.SnipeScan, evt.Pokemon, $"{evt.Bounds.LatStart},{evt.Bounds.LongStart}", $"{evt.Bounds.LatEnd},{evt.Bounds.LongEnd}"));
+        }
+
         public void HandleEvent(DisplayHighestsPokemonEvent evt, ISession session)
         {
             string strHeader;

--- a/PoGo.NecroBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.NecroBot.CLI/ConsoleEventListener.cs
@@ -182,7 +182,7 @@ namespace PoGo.NecroBot.CLI
 
         public void HandleEvent(SnipeScanEvent evt, ISession session)
         {
-            Logger.Write(session.Translation.GetTranslation(TranslationString.SnipeScan, evt.Pokemon, $"{evt.Bounds.Latitude},{evt.Bounds.Longitude}"));
+            Logger.Write(session.Translation.GetTranslation(TranslationString.SnipeScan, $"{evt.Bounds.Latitude},{evt.Bounds.Longitude}"));
         }
 
         public void HandleEvent(DisplayHighestsPokemonEvent evt, ISession session)

--- a/PoGo.NecroBot.CLI/ConsoleEventListener.cs
+++ b/PoGo.NecroBot.CLI/ConsoleEventListener.cs
@@ -182,7 +182,7 @@ namespace PoGo.NecroBot.CLI
 
         public void HandleEvent(SnipeScanEvent evt, ISession session)
         {
-            Logger.Write(session.Translation.GetTranslation(TranslationString.SnipeScan, evt.Pokemon, $"{evt.Bounds.LatStart},{evt.Bounds.LongStart}", $"{evt.Bounds.LatEnd},{evt.Bounds.LongEnd}"));
+            Logger.Write(session.Translation.GetTranslation(TranslationString.SnipeScan, evt.Pokemon, $"{evt.Bounds.Latitude},{evt.Bounds.Longitude}"));
         }
 
         public void HandleEvent(DisplayHighestsPokemonEvent evt, ISession session)

--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -233,7 +233,7 @@ namespace PoGo.NecroBot.Logic.Common
             new KeyValuePair<TranslationString, string>(Common.TranslationString.GoogleError, "Make sure you have entered the right Email & Password."),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsGoogle, "You need to fill out GoogleUsername and GooglePassword in auth.json!"),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsPtc, "You need to fill out PtcUsername and PtcPassword in auth.json!"),
-            new KeyValuePair<TranslationString, string>(Common.TranslationString.SnipeScan, "[Sniper] Scanning for {0} at {1}..."),
+            new KeyValuePair<TranslationString, string>(Common.TranslationString.SnipeScan, "[Sniper] Scanning for Snipeable Pokemon at {0}..."),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.NoPokemonToSnipe, "[Sniper] No Pokemon found to snipe!"),
         };
 

--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -113,6 +113,7 @@ namespace PoGo.NecroBot.Logic.Common
         GoogleError,
         MissingCredentialsGoogle,
         MissingCredentialsPtc
+        SnipeScan
     }
 
     public class Translation : ITranslation
@@ -232,6 +233,7 @@ namespace PoGo.NecroBot.Logic.Common
             new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsGoogle, "You need to fill out GoogleUsername and GooglePassword in auth.json!"),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsPtc, "You need to fill out PtcUsername and PtcPassword in auth.json!")
 
+            new KeyValuePair<TranslationString, string>(Common.TranslationString.SnipeScan, "[Sniper] Scanning for {0} at {1} to {2}..."),
         };
 
         public string GetTranslation(TranslationString translationString, params object[] data)

--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -113,7 +113,8 @@ namespace PoGo.NecroBot.Logic.Common
         GoogleError,
         MissingCredentialsGoogle,
         MissingCredentialsPtc,
-        SnipeScan
+        SnipeScan,
+        NoPokemonToSnipe
     }
 
     public class Translation : ITranslation
@@ -232,8 +233,8 @@ namespace PoGo.NecroBot.Logic.Common
             new KeyValuePair<TranslationString, string>(Common.TranslationString.GoogleError, "Make sure you have entered the right Email & Password."),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsGoogle, "You need to fill out GoogleUsername and GooglePassword in auth.json!"),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsPtc, "You need to fill out PtcUsername and PtcPassword in auth.json!"),
-
-            new KeyValuePair<TranslationString, string>(Common.TranslationString.SnipeScan, "[Sniper] Scanning for {0} at {1} to {2}..."),
+            new KeyValuePair<TranslationString, string>(Common.TranslationString.SnipeScan, "[Sniper] Scanning for {0} at {1}..."),
+            new KeyValuePair<TranslationString, string>(Common.TranslationString.NoPokemonToSnipe, "[Sniper] No Pokemon found to snipe!"),
         };
 
         public string GetTranslation(TranslationString translationString, params object[] data)

--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -112,7 +112,7 @@ namespace PoGo.NecroBot.Logic.Common
         GoogleTwoFactorAuthExplanation,
         GoogleError,
         MissingCredentialsGoogle,
-        MissingCredentialsPtc
+        MissingCredentialsPtc,
         SnipeScan
     }
 
@@ -231,7 +231,7 @@ namespace PoGo.NecroBot.Logic.Common
             new KeyValuePair<TranslationString, string>(Common.TranslationString.GoogleTwoFactorAuthExplanation, "Opening Google App-Passwords. Please make a new App Password (use Other as Device)"),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.GoogleError, "Make sure you have entered the right Email & Password."),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsGoogle, "You need to fill out GoogleUsername and GooglePassword in auth.json!"),
-            new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsPtc, "You need to fill out PtcUsername and PtcPassword in auth.json!")
+            new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsPtc, "You need to fill out PtcUsername and PtcPassword in auth.json!"),
 
             new KeyValuePair<TranslationString, string>(Common.TranslationString.SnipeScan, "[Sniper] Scanning for {0} at {1} to {2}..."),
         };

--- a/PoGo.NecroBot.Logic/Event/SnipeScanEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/SnipeScanEvent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PoGo.NecroBot.Logic.Event
+{
+    public class SnipeScanEvent : IEvent
+    {
+        public string Pokemon { get; set; }
+        public Bounds Bounds { get; set; }
+    }
+}

--- a/PoGo.NecroBot.Logic/Event/SnipeScanEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/SnipeScanEvent.cs
@@ -9,6 +9,6 @@ namespace PoGo.NecroBot.Logic.Event
     public class SnipeScanEvent : IEvent
     {
         public string Pokemon { get; set; }
-        public Bounds Bounds { get; set; }
+        public Location Bounds { get; set; }
     }
 }

--- a/PoGo.NecroBot.Logic/Event/SnipeScanEvent.cs
+++ b/PoGo.NecroBot.Logic/Event/SnipeScanEvent.cs
@@ -8,7 +8,6 @@ namespace PoGo.NecroBot.Logic.Event
 {
     public class SnipeScanEvent : IEvent
     {
-        public string Pokemon { get; set; }
         public Location Bounds { get; set; }
     }
 }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -9,6 +9,42 @@ using POGOProtos.Inventory.Item;
 
 namespace PoGo.NecroBot.Logic
 {
+    public class Bounds
+    {
+        public Bounds()
+        {
+        }
+
+        public Bounds(double latStart, double longStart, double latEnd, double longEnd)
+        {
+            LatStart = latStart;
+            LatEnd = latEnd;
+            LongStart = longStart;
+            LongEnd = longEnd;
+        }
+
+        public double LatStart { get; set; }
+        public double LatEnd { get; set; }
+        public double LongStart { get; set; }
+        public double LongEnd { get; set; }
+    }
+
+    public class SnipeSettings
+    {
+        public SnipeSettings()
+        {
+        }
+
+        public SnipeSettings(List<Bounds> locations, string pokemon)
+        {
+            Locations = locations;
+            Pokemon = pokemon;
+        }
+
+        public List<Bounds> Locations { get; set; }
+        public string Pokemon { get; set; }
+    }
+
     public class TransferFilter
     {
         public TransferFilter()
@@ -54,8 +90,10 @@ namespace PoGo.NecroBot.Logic
         int AmountOfPokemonToDisplayOnStart { get; }
         string TranslationLanguageCode { get; }
         string ProfilePath { get; }
+        string ConfigPath { get; }
         string ProfileConfigPath { get; }
         string GeneralConfigPath { get; }
+        bool SnipeAtPokestops { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 
@@ -66,6 +104,7 @@ namespace PoGo.NecroBot.Logic
         ICollection<PokemonId> PokemonsNotToCatch { get; }
 
         Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter { get; }
+        ICollection<SnipeSettings> PokemonToSnipe { get; } 
 
         bool StartupWelcomeDelay { get; }
     }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -90,7 +90,6 @@ namespace PoGo.NecroBot.Logic
         int AmountOfPokemonToDisplayOnStart { get; }
         string TranslationLanguageCode { get; }
         string ProfilePath { get; }
-        string ConfigPath { get; }
         string ProfileConfigPath { get; }
         string GeneralConfigPath { get; }
         bool SnipeAtPokestops { get; }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -9,24 +9,20 @@ using POGOProtos.Inventory.Item;
 
 namespace PoGo.NecroBot.Logic
 {
-    public class Bounds
+    public class Location
     {
-        public Bounds()
+        public Location()
         {
         }
 
-        public Bounds(double latStart, double longStart, double latEnd, double longEnd)
+        public Location(double latitude, double longitude)
         {
-            LatStart = latStart;
-            LatEnd = latEnd;
-            LongStart = longStart;
-            LongEnd = longEnd;
+            Latitude = latitude;
+            Longitude = longitude;
         }
 
-        public double LatStart { get; set; }
-        public double LatEnd { get; set; }
-        public double LongStart { get; set; }
-        public double LongEnd { get; set; }
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
     }
 
     public class SnipeSettings
@@ -35,13 +31,13 @@ namespace PoGo.NecroBot.Logic
         {
         }
 
-        public SnipeSettings(List<Bounds> locations, string pokemon)
+        public SnipeSettings(List<Location> locations, string pokemon)
         {
             Locations = locations;
             Pokemon = pokemon;
         }
 
-        public List<Bounds> Locations { get; set; }
+        public List<Location> Locations { get; set; }
         public string Pokemon { get; set; }
     }
 

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -31,14 +31,14 @@ namespace PoGo.NecroBot.Logic
         {
         }
 
-        public SnipeSettings(List<Location> locations, string pokemon)
+        public SnipeSettings(List<Location> locations, List<string> pokemon)
         {
             Locations = locations;
             Pokemon = pokemon;
         }
 
         public List<Location> Locations { get; set; }
-        public string Pokemon { get; set; }
+        public List<string> Pokemon { get; set; }
     }
 
     public class TransferFilter
@@ -99,7 +99,7 @@ namespace PoGo.NecroBot.Logic
         ICollection<PokemonId> PokemonsNotToCatch { get; }
 
         Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter { get; }
-        ICollection<SnipeSettings> PokemonToSnipe { get; } 
+        SnipeSettings PokemonToSnipe { get; } 
 
         bool StartupWelcomeDelay { get; }
     }

--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Event\FortUsedEvent.cs" />
     <Compile Include="Event\ItemRecycledEvent.cs" />
     <Compile Include="Event\NoPokeballEvent.cs" />
+    <Compile Include="Event\SnipeScanEvent.cs" />
     <Compile Include="Event\UpdateEvent.cs" />
     <Compile Include="Event\PokemonCaptureEvent.cs" />
     <Compile Include="Event\PokeStopListEvent.cs" />
@@ -107,6 +108,7 @@
     <Compile Include="Tasks\Login.cs" />
     <Compile Include="Tasks\RecycleItemsTask.cs" />
     <Compile Include="Tasks\RenamePokemonTask.cs" />
+    <Compile Include="Tasks\SnipePokemonTask.cs" />
     <Compile Include="Tasks\TransferDuplicatePokemonTask.cs" />
     <Compile Include="Event\UseLuckyEggEvent.cs" />
     <Compile Include="State\VersionCheckState.cs" />

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -20,7 +20,8 @@ namespace PoGo.NecroBot.CLI
         public AuthType AuthType;
 
 
-        [JsonIgnore] private string _filePath;
+        [JsonIgnore]
+        private string _filePath;
 
         public string GoogleRefreshToken;
         public string PtcUsername;
@@ -38,7 +39,7 @@ namespace PoGo.NecroBot.CLI
                 var input = File.ReadAllText(_filePath);
 
                 var settings = new JsonSerializerSettings();
-                settings.Converters.Add(new StringEnumConverter {CamelCaseText = true});
+                settings.Converters.Add(new StringEnumConverter { CamelCaseText = true });
 
                 JsonConvert.PopulateObject(input, this, settings);
             }
@@ -51,7 +52,7 @@ namespace PoGo.NecroBot.CLI
         public void Save(string path)
         {
             var output = JsonConvert.SerializeObject(this, Formatting.Indented,
-                new StringEnumConverter {CamelCaseText = true});
+                new StringEnumConverter { CamelCaseText = true });
 
             var folder = Path.GetDirectoryName(path);
             if (folder != null && !Directory.Exists(folder))
@@ -75,10 +76,14 @@ namespace PoGo.NecroBot.CLI
     {
         public int AmountOfPokemonToDisplayOnStart = 10;
 
-        [JsonIgnore] internal AuthSettings Auth = new AuthSettings();
-        [JsonIgnore] public string ProfilePath;
-        [JsonIgnore] public string ProfileConfigPath;
-        [JsonIgnore] public string GeneralConfigPath;
+        [JsonIgnore]
+        internal AuthSettings Auth = new AuthSettings();
+        [JsonIgnore]
+        public string ProfilePath;
+        [JsonIgnore]
+        public string ProfileConfigPath;
+        [JsonIgnore]
+        public string GeneralConfigPath;
 
         public bool AutoUpdate = true;
         public double DefaultAltitude = 10;
@@ -246,13 +251,14 @@ namespace PoGo.NecroBot.CLI
         {
             new SnipeSettings
             {
-                Locations = new List<Bounds>
+                Locations = new List<Location>
                 {
-                    new Bounds(38.535914,-121.300379,38.570683,-121.135584)
+                    new Location(38.55680748646112, -121.2383794784546)
                 },
                 Pokemon = PokemonId.Dratini.ToString()
             }
         };
+
         public static GlobalSettings Default => new GlobalSettings();
 
         public static GlobalSettings Load(string path)
@@ -268,7 +274,7 @@ namespace PoGo.NecroBot.CLI
                 var input = File.ReadAllText(configFile);
 
                 var jsonSettings = new JsonSerializerSettings();
-                jsonSettings.Converters.Add(new StringEnumConverter {CamelCaseText = true});
+                jsonSettings.Converters.Add(new StringEnumConverter { CamelCaseText = true });
                 jsonSettings.ObjectCreationHandling = ObjectCreationHandling.Replace;
                 jsonSettings.DefaultValueHandling = DefaultValueHandling.Populate;
 
@@ -282,6 +288,21 @@ namespace PoGo.NecroBot.CLI
             if (settings.WebSocketPort == 0)
             {
                 settings.WebSocketPort = 14251;
+            }
+
+            if (settings.PokemonToSnipe == null)
+            {
+                settings.PokemonToSnipe = new List<SnipeSettings>
+                {
+                    new SnipeSettings
+                    {
+                        Locations = new List<Location>
+                        {
+                            new Location(38.55680748646112, -121.2383794784546)
+                        },
+                        Pokemon = PokemonId.Dratini.ToString()
+                    }
+                };
             }
 
             settings.ProfilePath = profilePath;
@@ -302,7 +323,7 @@ namespace PoGo.NecroBot.CLI
         public void Save(string fullPath)
         {
             var output = JsonConvert.SerializeObject(this, Formatting.Indented,
-                new StringEnumConverter {CamelCaseText = true});
+                new StringEnumConverter { CamelCaseText = true });
 
             var folder = Path.GetDirectoryName(fullPath);
             if (folder != null && !Directory.Exists(folder))

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -247,15 +247,15 @@ namespace PoGo.NecroBot.CLI
             {PokemonId.Mew, new TransferFilter(0, 0, 10)}
         };
 
-        public List<SnipeSettings> PokemonToSnipe = new List<SnipeSettings>
+        public SnipeSettings PokemonToSnipe = new SnipeSettings
         {
-            new SnipeSettings
+            Locations = new List<Location>
             {
-                Locations = new List<Location>
-                {
-                    new Location(38.55680748646112, -121.2383794784546)
-                },
-                Pokemon = PokemonId.Dratini.ToString()
+                new Location(38.55680748646112, -121.2383794784546)
+            },
+            Pokemon = new List<string>()
+            {
+                PokemonId.Dratini.ToString()
             }
         };
 
@@ -495,6 +495,6 @@ namespace PoGo.NecroBot.CLI
         public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter => _settings.PokemonsTransferFilter;
         public bool StartupWelcomeDelay => _settings.StartupWelcomeDelay;
         public bool SnipeAtPokestops => _settings.SnipeAtPokestops;
-        public ICollection<SnipeSettings> PokemonToSnipe => _settings.PokemonToSnipe;
+        public SnipeSettings PokemonToSnipe => _settings.PokemonToSnipe;
     }
 }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -292,17 +292,7 @@ namespace PoGo.NecroBot.CLI
 
             if (settings.PokemonToSnipe == null)
             {
-                settings.PokemonToSnipe = new List<SnipeSettings>
-                {
-                    new SnipeSettings
-                    {
-                        Locations = new List<Location>
-                        {
-                            new Location(38.55680748646112, -121.2383794784546)
-                        },
-                        Pokemon = PokemonId.Dratini.ToString()
-                    }
-                };
+                settings.PokemonToSnipe = Default.PokemonToSnipe;
             }
 
             settings.ProfilePath = profilePath;

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -108,6 +108,7 @@ namespace PoGo.NecroBot.CLI
         public bool UsePokemonToNotCatchFilter = false;
         public int WebSocketPort = 14251;
         public bool StartupWelcomeDelay = true;
+        public bool SnipeAtPokestops = true;
 
         public List<KeyValuePair<ItemId, int>> ItemRecycleFilter = new List<KeyValuePair<ItemId, int>>
         {
@@ -239,6 +240,18 @@ namespace PoGo.NecroBot.CLI
             {PokemonId.Eevee, new TransferFilter(750, 92, 2)},
             {PokemonId.Gyarados, new TransferFilter(1200, 90, 5)},
             {PokemonId.Mew, new TransferFilter(0, 0, 10)}
+        };
+
+        public List<SnipeSettings> PokemonToSnipe = new List<SnipeSettings>
+        {
+            new SnipeSettings
+            {
+                Locations = new List<Bounds>
+                {
+                    new Bounds(38.535914,-121.300379,38.570683,-121.135584)
+                },
+                Pokemon = PokemonId.Dratini.ToString()
+            }
         };
         public static GlobalSettings Default => new GlobalSettings();
 
@@ -470,5 +483,7 @@ namespace PoGo.NecroBot.CLI
         public ICollection<PokemonId> PokemonsNotToCatch => _settings.PokemonsToIgnore;
         public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter => _settings.PokemonsTransferFilter;
         public bool StartupWelcomeDelay => _settings.StartupWelcomeDelay;
+        public bool SnipeAtPokestops => _settings.SnipeAtPokestops;
+        public ICollection<SnipeSettings> PokemonToSnipe => _settings.PokemonToSnipe;
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -94,6 +94,11 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                             await RecycleItemsTask.Execute(session);
 
+                            if (session.LogicSettings.SnipeAtPokestops)
+                            {
+                                await SnipePokemonTask.Execute(session);
+                            }
+
                             if (session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
                                 session.LogicSettings.EvolveAllPokemonAboveIv)
                             {

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -150,6 +150,10 @@ namespace PoGo.NecroBot.Logic.Tasks
                         await session.Inventory.RefreshCachedInventory();
                     }
                     await RecycleItemsTask.Execute(session);
+                    if (session.LogicSettings.SnipeAtPokestops)
+                    {
+                        await SnipePokemonTask.Execute(session);
+                    }
                     if (session.LogicSettings.EvolveAllPokemonWithEnoughCandy || session.LogicSettings.EvolveAllPokemonAboveIv)
                     {
                         await EvolvePokemonTask.Execute(session);

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.State;
+using POGOProtos.Enums;
+using POGOProtos.Networking.Responses;
+
+namespace PoGo.NecroBot.Logic.Tasks
+{
+    public class PokemonLocation
+    {
+        public double expires { get; set; }
+        public double latitude { get; set; }
+        public double longitude { get; set; }
+        public int pokemon_id { get; set; }
+        public string pokemon_name { get; set; }
+
+        public override int GetHashCode()
+        {
+            return this.ToString().GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return $"{expires}{latitude}{longitude}{pokemon_id}";
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.ToString().Equals(obj.ToString());
+        }
+    }
+
+    public class ScanResult
+    {
+        public List<PokemonLocation> pokemons { get; set; }
+    }
+
+    public static class SnipePokemonTask
+    {
+        public static List<PokemonLocation> locsVisited = new List<PokemonLocation>();
+
+        public static async Task Execute(ISession session)
+        {
+            DateTime st = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            TimeSpan t = (DateTime.Now.ToUniversalTime() - st);
+            var currentTimestamp = t.TotalMilliseconds;
+
+            foreach (var snipeSettings in session.LogicSettings.PokemonToSnipe)
+            {
+                var pokemonName = snipeSettings.Pokemon;
+                PokemonId pokemonId = Enum.Parse(typeof(PokemonId), pokemonName) as PokemonId? ?? PokemonId.Missingno;
+
+                foreach (var location in snipeSettings.Locations)
+                {
+                    session.EventDispatcher.Send(new SnipeScanEvent()
+                    {
+                        Bounds = location,
+                        Pokemon = pokemonName
+                    });
+
+                    var uri =
+                        $"https://skiplagged.com/api/pokemon.php?bounds={location.LatStart},{location.LongStart},{location.LatEnd},{location.LongEnd}";
+
+                    var request = WebRequest.CreateHttp(uri);
+                    request.Accept = "application/json";
+                    request.Method = "GET";
+
+                    var resp = request.GetResponse();
+                    var reader = new StreamReader(resp.GetResponseStream());
+
+                    var scanResult = JsonConvert.DeserializeObject<ScanResult>(reader.ReadToEnd());
+
+                    var locationsToSnipe = scanResult.pokemons.Where(q =>
+                        q.pokemon_id == (int)pokemonId
+                        && !locsVisited.Contains(q)
+                        && q.expires < currentTimestamp).ToList();
+
+                    if (locationsToSnipe.Any())
+                    {
+                        foreach (var pokemonLocation in locationsToSnipe)
+                        {
+                            locsVisited.Add(pokemonLocation);
+
+                            await session.Client.Player.UpdatePlayerLocation(pokemonLocation.latitude, pokemonLocation.longitude, session.Settings.DefaultAltitude);
+
+                            session.EventDispatcher.Send(new UpdatePositionEvent()
+                            {
+                                Longitude = pokemonLocation.longitude,
+                                Latitude = pokemonLocation.latitude
+                            });
+
+                            var mapObjects = session.Client.Map.GetMapObjects().Result;
+                            var catchablePokemon =
+                                mapObjects.MapCells.SelectMany(q => q.CatchablePokemons)
+                                    .Where(q => q.PokemonId == pokemonId)
+                                    .ToList();
+
+                            foreach (var pokemon in catchablePokemon)
+                            {
+                                var encounter = session.Client.Encounter.EncounterPokemon(pokemon.EncounterId, pokemon.SpawnPointId).Result;
+
+                                if (encounter.Status == EncounterResponse.Types.Status.EncounterSuccess)
+                                {
+                                    await CatchPokemonTask.Execute(session, encounter, pokemon);
+                                }
+                                else if (encounter.Status == EncounterResponse.Types.Status.PokemonInventoryFull)
+                                {
+                                    session.EventDispatcher.Send(new WarnEvent
+                                    {
+                                        Message = session.Translation.GetTranslation(Common.TranslationString.InvFullTransferManually)
+                                    });
+                                }
+                                else
+                                {
+                                    session.EventDispatcher.Send(new WarnEvent { Message = session.Translation.GetTranslation(Common.TranslationString.EncounterProblem, encounter.Status) });
+                                }
+
+                                if (!Equals(catchablePokemon.ElementAtOrDefault(catchablePokemon.Count() - 1), pokemon))
+                                {
+                                    await Task.Delay(5000);
+                                }
+                            }
+
+                            await session.Client.Player.UpdatePlayerLocation(session.Settings.DefaultLatitude, session.Settings.DefaultLongitude, session.Settings.DefaultAltitude);
+
+                            session.EventDispatcher.Send(new UpdatePositionEvent()
+                            {
+                                Latitude = session.Settings.DefaultLatitude,
+                                Longitude = session.Settings.DefaultLongitude
+                            });
+
+                            await Task.Delay(1000);
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+}

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -170,16 +170,26 @@ namespace PoGo.NecroBot.Logic.Tasks
         private static ScanResult SnipeScanForPokemon(Location location)
         {
             var uri = $"https://pokevision.com/map/data/{location.Latitude}/{location.Longitude}";
+            ScanResult scanResult;
+            try
+            {
+                var request = WebRequest.CreateHttp(uri);
+                request.Accept = "application/json";
+                request.Method = "GET";
 
-            var request = WebRequest.CreateHttp(uri);
-            request.Accept = "application/json";
-            request.Method = "GET";
+                var resp = request.GetResponse();
+                var reader = new StreamReader(resp.GetResponseStream());
 
-            var resp = request.GetResponse();
-            var reader = new StreamReader(resp.GetResponseStream());
-
-            var scanResult = JsonConvert.DeserializeObject<ScanResult>(reader.ReadToEnd());
-
+                scanResult = JsonConvert.DeserializeObject<ScanResult>(reader.ReadToEnd());
+            }
+            catch (Exception e)
+            {
+                scanResult = new ScanResult()
+                {
+                    status = "fail",
+                    pokemon = new List<PokemonLocation>()
+                };
+            }
             return scanResult;
         } 
     }


### PR DESCRIPTION
Feature will work with the rest of the logic every 5 Pokestops to snipe configured areas for Pokemon. May need some updates for data calls sine I'm relying on an external API call to determine spawns.

Utilizes two new settings:
bool: SnipeAtPokestops
List: PokemonToSnipe - List of locations/pokemon to snipe.