### PR TITLE
getting this error after i hit enter

### DIFF
--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Device" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/PoGo.NecroBot.Logic/State/VersionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/VersionCheckState.cs
@@ -1,10 +1,12 @@
 ﻿#region using directives
 
 using System;
+using System.IO;
+using System.IO.Compression;
 using System.Net;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.Logging;
 
 #endregion
 
@@ -13,28 +15,83 @@ namespace PoGo.NecroBot.Logic.State
     public class VersionCheckState : IState
     {
         public static string VersionUri =
-            "https://raw.githubusercontent.com/NecronomiconCoding/Pokemon-Go-Bot/master/PokemonGo.RocketAPI/Properties/AssemblyInfo.cs";
+            "https://raw.githubusercontent.com/NecronomiconCoding/NecroBot/master/PoGo.NecroBot.Logic/Properties/AssemblyInfo.cs";
+
+        public static string LatestReleaseApi =
+            "https://api.github.com/repos/NecronomiconCoding/NecroBot/releases/latest";
+
+        public static bool AutoUpdate = true; //TODO: read from clientsettings
 
         public IState Execute(Context ctx, StateMachine machine)
         {
-            if (IsLatest())
-            {
-                machine.Fire(new NoticeEvent
-                {
-                    Message =
-                        "Awesome! You have already got the newest version! " +
-                        Assembly.GetExecutingAssembly().GetName().Version
-                });
-            }
-            else
-            {
-                machine.Fire(new WarnEvent
-                {
-                    Message = "There is a new Version available: https://github.com/NecronomiconCoding/Pokemon-Go-Bot"
-                });
-            }
+            CleanupOldFiles();
 
-            return new LoginState();
+            if (IsLatest())
+                //has the newest version NOTE: NOT YET IMPLEMENTED. rest of the code works, just need to check current version against latest
+            {
+                Logger.Write("Using newest Release of NecroBot");
+                return new LoginState();
+            }
+            Logger.Write(AutoUpdate
+                ? "AutoUpdate is enabled, please wait for the bot to begin updating."
+                : "AutoUpdate is disabled. Get the latest release from:\n https://github.com/NecronomiconCoding/NecroBot/releases");
+
+            //TODO: change constant URL to latest Release url provided by the API page (see latestReleaseAPI a few lines up)
+            const string url = "https://github.com/NecronomiconCoding/NecroBot/releases/download/v0.1.5/";
+            const string zipName = "Release.zip";
+            const string downloadLink = url + zipName;
+            var baseDir = new DirectoryInfo(Directory.GetCurrentDirectory());
+            var downloadFilePath = baseDir + "\\" + zipName;
+            var tempPath = baseDir + "\\tmp";
+
+
+            if (DownloadFile(downloadLink, downloadFilePath))
+            {
+                if (UnpackFile(downloadFilePath, tempPath))
+                {
+                    var extractedDir = tempPath + "\\Release";
+                    var destinationDir = baseDir + "\\";
+                    if (MoveAllFiles(extractedDir, destinationDir))
+                    {
+
+                    }
+                }
+            }
+            CleanupOldFiles(); //cleansup most of the .old files that were created when the bot updated
+            Environment.Exit(0);
+            return null;
+        }
+
+        public static void CleanupOldFiles()
+        {
+            var di = new DirectoryInfo(Directory.GetCurrentDirectory());
+            var files = di.GetFiles("*.old");
+            foreach (var file in files)
+                try
+                {
+                    //Logger.Write($"\nDEBUG: Old file found: {file.FullName}");
+                    File.Delete(file.FullName);
+                }
+                catch
+                {
+                    // ignored
+                }
+        }
+
+        public static bool DownloadFile(string url, string dest)
+        {
+            using (var client = new WebClient())
+            {
+                try
+                {
+                    client.DownloadFile(url, dest);
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+                return true;
+            }
         }
 
         private static string DownloadServerVersion()
@@ -45,7 +102,8 @@ namespace PoGo.NecroBot.Logic.State
             }
         }
 
-        public bool IsLatest()
+
+        public bool IsLatest() //TODO: actually use this function
         {
             try
             {
@@ -68,6 +126,60 @@ namespace PoGo.NecroBot.Logic.State
             }
 
             return false;
+        }
+
+        public static bool MoveAllFiles(string sourceFolder, string destFolder)
+        {
+            if (!Directory.Exists(destFolder))
+                Directory.CreateDirectory(destFolder);
+
+            var oldfiles = Directory.GetFiles(destFolder);
+            foreach (var old in oldfiles)
+            {
+                File.Move(old, old + ".old");
+            }
+
+            try
+            {
+                var files = Directory.GetFiles(sourceFolder);
+                foreach (var file in files)
+                {
+                    var name = Path.GetFileName(file);
+                    if (name == null) continue;
+                    var dest = Path.Combine(destFolder, name);
+                    File.Copy(file, dest, true);
+                }
+
+                var folders = Directory.GetDirectories(sourceFolder);
+
+                foreach (var folder in folders)
+                {
+                    var name = Path.GetFileName(folder);
+                    if (name == null) continue;
+                    var dest = Path.Combine(destFolder, name);
+                    MoveAllFiles(folder, dest);
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public static bool UnpackFile(string sourceTarget, string destPath)
+        {
+            var source = sourceTarget;
+            var dest = destPath;
+            try
+            {
+                ZipFile.ExtractToDirectory(source, dest);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
[17:23:03] (ERROR) PokemonGo.RocketAPI.Exceptions.InvalidResponseException: Exce
ption of type 'PokemonGo.RocketAPI.Exceptions.InvalidResponseException' was thro
wn.
   at PokemonGo.RocketAPI.Extensions.HttpClientExtensions.<PostProtoPayload>d__0
`2.MoveNext() in C:\Users\tvgfx\Documents\Pokemon Go Bot\FeroxRev\PokemonGo.Rock
etAPI\Extensions\HttpClientExtensions.cs:line 20
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNot
ification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at PokemonGo.RocketAPI.Rpc.BaseRpc.<PostProtoPayload>d__7`2.MoveNext() in C:\
Users\tvgfx\Documents\Pokemon Go Bot\FeroxRev\PokemonGo.RocketAPI\Rpc\BaseRpc.cs
:line 35
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNot
ification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at PokemonGo.RocketAPI.Rpc.Player.<UpdatePlayerLocation>d__1.MoveNext() in C:
\Users\tvgfx\Documents\Pokemon Go Bot\FeroxRev\PokemonGo.RocketAPI\Rpc\Player.cs
:line 40
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNot
ification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at PoGo.NecroBot.Logic.Navigation.<HumanLikeWalking>d__3.MoveNext() in C:\Use
rs\tvgfx\Documents\Pokemon Go Bot\PoGo.NecroBot.Logic\Navigation.cs:line 48
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNot
ification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at PoGo.NecroBot.Logic.Tasks.FarmPokestopsTask.<Execute>d__1.MoveNext() in C:
\Users\tvgfx\Documents\Pokemon Go Bot\PoGo.NecroBot.Logic\Tasks\FarmPokestopsTas
k.cs:line 77
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNot
ification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at PoGo.NecroBot.Logic.State.FarmState.<Execute>d__0.MoveNext() in C:\Users\t
vgfx\Documents\Pokemon Go Bot\PoGo.NecroBot.Logic\State\FarmState.cs:line 42
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNot
ification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at PoGo.NecroBot.Logic.State.StateMachine.<Start>d__4.MoveNext() in C:\Users\
tvgfx\Documents\Pokemon Go Bot\PoGo.NecroBot.Logic\State\StateMachine.cs:line 34

