### PR TITLE
Rename all pokemon with IV that aren't already nicknamed.

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -83,6 +83,7 @@ namespace PoGo.NecroBot.Logic
         float EvolveAboveIvValue { get; }
         bool DumpPokemonStats { get; }
         bool RenameAboveIv { get; }
+        bool RenameAllIv { get; }
         string RenameTemplate { get; }
         int AmountOfPokemonToDisplayOnStart { get; }
         string TranslationLanguageCode { get; }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -108,6 +108,7 @@ namespace PoGo.NecroBot.CLI
         public bool KeepPokemonsThatCanEvolve = false;
         public bool PrioritizeIvOverCp = true;
         public bool RenameAboveIv = true;
+        public bool RenameAllIv = false;
         public string RenameTemplate = "{0}_{1}";
         public bool TransferDuplicatePokemon = true;
         public string TranslationLanguageCode = "en";
@@ -500,6 +501,7 @@ namespace PoGo.NecroBot.CLI
         public bool EvolveAllPokemonAboveIv => _settings.EvolveAllPokemonAboveIv;
         public float EvolveAboveIvValue => _settings.EvolveAboveIvValue;
         public bool RenameAboveIv => _settings.RenameAboveIv;
+        public bool RenameAllIv => _settings.RenameAllIv;
         public string RenameTemplate => _settings.RenameTemplate;
         public int AmountOfPokemonToDisplayOnStart => _settings.AmountOfPokemonToDisplayOnStart;
         public bool DumpPokemonStats => _settings.DumpPokemonStats;

--- a/PoGo.NecroBot.Logic/State/FarmState.cs
+++ b/PoGo.NecroBot.Logic/State/FarmState.cs
@@ -21,7 +21,7 @@ namespace PoGo.NecroBot.Logic.State
                 await TransferDuplicatePokemonTask.Execute(session);
             }
 
-            if (session.LogicSettings.RenameAboveIv)
+            if (session.LogicSettings.RenameAboveIv || session.LogicSettings.RenameAllIv)
             {
                 await RenamePokemonTask.Execute(session);
             }

--- a/PoGo.NecroBot.Logic/Tasks/Farm.cs
+++ b/PoGo.NecroBot.Logic/Tasks/Farm.cs
@@ -34,7 +34,7 @@ namespace PoGo.NecroBot.Logic.Service
                 TransferDuplicatePokemonTask.Execute(_session).Wait();
             }
 
-            if (_session.LogicSettings.RenameAboveIv)
+            if (_session.LogicSettings.RenameAboveIv || _session.LogicSettings.RenameAllIv)
             {
                 RenamePokemonTask.Execute(_session).Wait();
             }

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -110,7 +110,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                                 await TransferDuplicatePokemonTask.Execute(session);
                             }
 
-                            if (session.LogicSettings.RenameAboveIv)
+                            if (session.LogicSettings.RenameAboveIv || session.LogicSettings.RenameAllIv)
                             {
                                 await RenamePokemonTask.Execute(session);
                             }

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -162,7 +162,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     {
                         await TransferDuplicatePokemonTask.Execute(session);
                     }
-                    if (session.LogicSettings.RenameAboveIv)
+                    if (session.LogicSettings.RenameAboveIv || session.LogicSettings.RenameAllIv)
                     {
                         await RenamePokemonTask.Execute(session);
                     }

--- a/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RenamePokemonTask.cs
@@ -20,6 +20,8 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             foreach (var pokemon in pokemons)
             {
+                if (pokemon.Nickname.Length != 0) continue;
+
                 double perfection = Math.Round(PokemonInfo.CalculatePokemonPerfection(pokemon));
                 string pokemonName = pokemon.PokemonId.ToString();
                 // iv number + templating part + pokemonName <= 12
@@ -31,8 +33,12 @@ namespace PoGo.NecroBot.Logic.Tasks
                 string newNickname = String.Format(session.LogicSettings.RenameTemplate, pokemonName, perfection);
                 string oldNickname = (pokemon.Nickname.Length != 0) ? pokemon.Nickname : pokemon.PokemonId.ToString();
 
-                if (perfection >= session.LogicSettings.KeepMinIvPercentage && newNickname != oldNickname &&
-                    session.LogicSettings.RenameAboveIv)
+                if (newNickname != oldNickname &&
+                    (
+                        (session.LogicSettings.RenameAboveIv && perfection >= session.LogicSettings.KeepMinIvPercentage) ||
+                        session.LogicSettings.RenameAllIv
+                    )
+                )
                 {
                     await session.Client.Inventory.NicknamePokemon(pokemon.Id, newNickname);
 


### PR DESCRIPTION
Adds another configuration option that renames anything that's not custom named, to be another choice over the renaming only above capture IV minimums.