### PR TITLE
Major Issue (PokemonsToIgnore, PokemonsToEvolve, PokemonsNotToTransfer Fix)

### DIFF
--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Device" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/PoGo.NecroBot.Logic/State/VersionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/VersionCheckState.cs
@@ -1,10 +1,12 @@
 ﻿#region using directives
 
 using System;
+using System.IO;
+using System.IO.Compression;
 using System.Net;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.Logging;
 
 #endregion
 
@@ -13,28 +15,83 @@ namespace PoGo.NecroBot.Logic.State
     public class VersionCheckState : IState
     {
         public static string VersionUri =
-            "https://raw.githubusercontent.com/NecronomiconCoding/Pokemon-Go-Bot/master/PokemonGo.RocketAPI/Properties/AssemblyInfo.cs";
+            "https://raw.githubusercontent.com/NecronomiconCoding/NecroBot/master/PoGo.NecroBot.Logic/Properties/AssemblyInfo.cs";
+
+        public static string LatestReleaseApi =
+            "https://api.github.com/repos/NecronomiconCoding/NecroBot/releases/latest";
+
+        public static bool AutoUpdate = true; //TODO: read from clientsettings
 
         public IState Execute(Context ctx, StateMachine machine)
         {
-            if (IsLatest())
-            {
-                machine.Fire(new NoticeEvent
-                {
-                    Message =
-                        "Awesome! You have already got the newest version! " +
-                        Assembly.GetExecutingAssembly().GetName().Version
-                });
-            }
-            else
-            {
-                machine.Fire(new WarnEvent
-                {
-                    Message = "There is a new Version available: https://github.com/NecronomiconCoding/Pokemon-Go-Bot"
-                });
-            }
+            CleanupOldFiles();
 
-            return new LoginState();
+            if (IsLatest())
+                //has the newest version NOTE: NOT YET IMPLEMENTED. rest of the code works, just need to check current version against latest
+            {
+                Logger.Write("Using newest Release of NecroBot");
+                return new LoginState();
+            }
+            Logger.Write(AutoUpdate
+                ? "AutoUpdate is enabled, please wait for the bot to begin updating."
+                : "AutoUpdate is disabled. Get the latest release from:\n https://github.com/NecronomiconCoding/NecroBot/releases");
+
+            //TODO: change constant URL to latest Release url provided by the API page (see latestReleaseAPI a few lines up)
+            const string url = "https://github.com/NecronomiconCoding/NecroBot/releases/download/v0.1.5/";
+            const string zipName = "Release.zip";
+            const string downloadLink = url + zipName;
+            var baseDir = new DirectoryInfo(Directory.GetCurrentDirectory());
+            var downloadFilePath = baseDir + "\\" + zipName;
+            var tempPath = baseDir + "\\tmp";
+
+
+            if (DownloadFile(downloadLink, downloadFilePath))
+            {
+                if (UnpackFile(downloadFilePath, tempPath))
+                {
+                    var extractedDir = tempPath + "\\Release";
+                    var destinationDir = baseDir + "\\";
+                    if (MoveAllFiles(extractedDir, destinationDir))
+                    {
+
+                    }
+                }
+            }
+            CleanupOldFiles(); //cleansup most of the .old files that were created when the bot updated
+            Environment.Exit(0);
+            return null;
+        }
+
+        public static void CleanupOldFiles()
+        {
+            var di = new DirectoryInfo(Directory.GetCurrentDirectory());
+            var files = di.GetFiles("*.old");
+            foreach (var file in files)
+                try
+                {
+                    //Logger.Write($"\nDEBUG: Old file found: {file.FullName}");
+                    File.Delete(file.FullName);
+                }
+                catch
+                {
+                    // ignored
+                }
+        }
+
+        public static bool DownloadFile(string url, string dest)
+        {
+            using (var client = new WebClient())
+            {
+                try
+                {
+                    client.DownloadFile(url, dest);
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+                return true;
+            }
         }
 
         private static string DownloadServerVersion()
@@ -45,7 +102,8 @@ namespace PoGo.NecroBot.Logic.State
             }
         }
 
-        public bool IsLatest()
+
+        public bool IsLatest() //TODO: actually use this function
         {
             try
             {
@@ -68,6 +126,60 @@ namespace PoGo.NecroBot.Logic.State
             }
 
             return false;
+        }
+
+        public static bool MoveAllFiles(string sourceFolder, string destFolder)
+        {
+            if (!Directory.Exists(destFolder))
+                Directory.CreateDirectory(destFolder);
+
+            var oldfiles = Directory.GetFiles(destFolder);
+            foreach (var old in oldfiles)
+            {
+                File.Move(old, old + ".old");
+            }
+
+            try
+            {
+                var files = Directory.GetFiles(sourceFolder);
+                foreach (var file in files)
+                {
+                    var name = Path.GetFileName(file);
+                    if (name == null) continue;
+                    var dest = Path.Combine(destFolder, name);
+                    File.Copy(file, dest, true);
+                }
+
+                var folders = Directory.GetDirectories(sourceFolder);
+
+                foreach (var folder in folders)
+                {
+                    var name = Path.GetFileName(folder);
+                    if (name == null) continue;
+                    var dest = Path.Combine(destFolder, name);
+                    MoveAllFiles(folder, dest);
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public static bool UnpackFile(string sourceTarget, string destPath)
+        {
+            var source = sourceTarget;
+            var dest = destPath;
+            try
+            {
+                ZipFile.ExtractToDirectory(source, dest);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION

[config2.txt](https://github.com/NecronomiconCoding/NecroBot/files/389771/config2.txt)

I kept wondering why specific pokemon weren't following these rules, 
than when I was exploring the pokesniper, I decided to add more creatures to the config to more successfully sniper more breeds of poke's. List went:
![lowercase2](https://cloud.githubusercontent.com/assets/20715573/17235811/f38409e4-5511-11e6-82c5-ab5b07c72d4e.png)
Noticed the bot would run this error:
![lowercase1](https://cloud.githubusercontent.com/assets/20715573/17235820/02f2129a-5512-11e6-866f-3fb50bc6ec16.png)

Basically in conclusion when I Capatalized the Pokename's the bot would detect them.
For reason this bot is case-sensitive, which might explain why default lower-cased configs won't ignore, evolve, transfer specific creatures/

Updated config list:
{
  "AmountOfPokemonToDisplayOnStart": 10,
  "AutoUpdate": true,
  "DefaultAltitude": 10.0,
  "DefaultLatitude": ,
  "DefaultLongitude": ,
  "DelayBetweenPokemonCatch": 2000,
  "DelayBetweenPlayerActions": 2000,
  "EvolveAboveIvValue": 90.0,
  "EvolveAllPokemonAboveIv": false,
  "EvolveAllPokemonWithEnoughCandy": false,
  "UseLuckyEggsMinPokemonAmount": 30,
  "UseLuckyEggsWhileEvolving": false,
  "UseEggIncubators": true,
  "DumpPokemonStats": false,
  "GpxFile": "GPXPath.GPX",
  "UseGpxPathing": false,
  "WalkingSpeedInKilometerPerHour": 50.0,
  "MaxTravelDistanceInMeters": 1300,
  "KeepMinCp": 1600,
  "KeepMinDuplicatePokemon": 1,
  "KeepMinIvPercentage": 95.0,
  "KeepPokemonsThatCanEvolve": false,
  "PrioritizeIvOverCp": true,
  "RenameAboveIv": true,
  "RenameTemplate": "{0}_{1}",
  "TransferDuplicatePokemon": true,
  "TranslationLanguageCode": "en",
  "UsePokemonToNotCatchFilter": false,
  "WebSocketPort": 14251,
  "StartupWelcomeDelay": true,
  "SnipeAtPokestops": true,
  "ItemRecycleFilter": [
    {
      "Key": "itemUnknown",
      "Value": 0
    },
    {
      "Key": "itemPokeBall",
      "Value": 25
    },
    {
      "Key": "itemGreatBall",
      "Value": 50
    },
    {
      "Key": "itemUltraBall",
      "Value": 100
    },
    {
      "Key": "itemMasterBall",
      "Value": 100
    },
    {
      "Key": "itemPotion",
      "Value": 0
    },
    {
      "Key": "itemSuperPotion",
      "Value": 10
    },
    {
      "Key": "itemHyperPotion",
      "Value": 40
    },
    {
      "Key": "itemMaxPotion",
      "Value": 75
    },
    {
      "Key": "itemRevive",
      "Value": 25
    },
    {
      "Key": "itemMaxRevive",
      "Value": 50
    },
    {
      "Key": "itemLuckyEgg",
      "Value": 200
    },
    {
      "Key": "itemIncenseOrdinary",
      "Value": 100
    },
    {
      "Key": "itemIncenseSpicy",
      "Value": 100
    },
    {
      "Key": "itemIncenseCool",
      "Value": 100
    },
    {
      "Key": "itemIncenseFloral",
      "Value": 100
    },
    {
      "Key": "itemTroyDisk",
      "Value": 100
    },
    {
      "Key": "itemXAttack",
      "Value": 100
    },
    {
      "Key": "itemXDefense",
      "Value": 100
    },
    {
      "Key": "itemXMiracle",
      "Value": 100
    },
    {
      "Key": "itemRazzBerry",
      "Value": 50
    },
    {
      "Key": "itemBlukBerry",
      "Value": 10
    },
    {
      "Key": "itemNanabBerry",
      "Value": 10
    },
    {
      "Key": "itemWeparBerry",
      "Value": 30
    },
    {
      "Key": "itemPinapBerry",
      "Value": 30
    },
    {
      "Key": "itemSpecialCamera",
      "Value": 100
    },
    {
      "Key": "itemIncubatorBasicUnlimited",
      "Value": 100
    },
    {
      "Key": "itemIncubatorBasic",
      "Value": 100
    },
    {
      "Key": "itemPokemonStorageUpgrade",
      "Value": 100
    },
    {
      "Key": "itemItemStorageUpgrade",
      "Value": 100
    }
  ],
  "PokemonsNotToTransfer": [
    "Aerodactyl",
    "Venusaur",
    "Charizard",
    "Blastoise",
    "Nidoqueen",
    "Nidoking",
    "Clefable",
    "Vileplume",
    "Arcanine",
    "Poliwrath",
    "Machamp",
    "Victreebel",
    "Golem",
    "Slowbro",
    "Farfetchd",
    "Muk",
    "Exeggutor",
    "Lickitung",
    "Chansey",
    "Kangaskhan",
    "MrMime",
    "Gyarados",
    "Lapras",
    "Ditto",
    "Vaporeon",
    "Jolteon",
    "Flareon",
    "Porygon",
    "Snorlax",
    "Articuno",
    "Zapdos",
    "Moltres",
    "Dragonite",
    "Mewtwo",
    "Mew"
  ],
  "PokemonsToEvolve": [
    "Caterpie",
    "Weedle",
    "Pidgey",
    "Rattata",
    "Spearow",
    "Zubat",
    "Doduo",
    "Goldeen",
    "Paras",
    "Ekans",
    "Staryu",
    "Psyduck",
    "Krabby",
    "Venonat"
  ],
  "PokemonsToIgnore": [
    "Caterpie",
    "Weedle",
    "Pidgey",
    "Rattata",
    "Spearow",
    "Zubat",
    "Doduo"
  ],
  "PokemonsTransferFilter": {
    "Pidgeotto": {
      "KeepMinCp": 1500,
      "KeepMinIvPercentage": 90.0,
      "KeepMinDuplicatePokemon": 1
    },
    "Fearow": {
      "KeepMinCp": 1500,
      "KeepMinIvPercentage": 90.0,
      "KeepMinDuplicatePokemon": 2
    },
    "Zubat": {
      "KeepMinCp": 500,
      "KeepMinIvPercentage": 90.0,
      "KeepMinDuplicatePokemon": 2
    },
    "Golbat": {
      "KeepMinCp": 1500,
      "KeepMinIvPercentage": 90.0,
      "KeepMinDuplicatePokemon": 2
    },
    "Pinsir": {
      "KeepMinCp": 1500,
      "KeepMinIvPercentage": 95.0,
      "KeepMinDuplicatePokemon": 2
    },
    "Golduck": {
      "KeepMinCp": 1350,
      "KeepMinIvPercentage": 95.0,
      "KeepMinDuplicatePokemon": 2
    },
    "Tentacruel": {
      "KeepMinCp": 1350,
      "KeepMinIvPercentage": 95.0,
      "KeepMinDuplicatePokemon": 2
    },
    "Starmie": {
      "KeepMinCp": 1350,
      "KeepMinIvPercentage": 95.0,
      "KeepMinDuplicatePokemon": 2
    },
    "Eevee": {
      "KeepMinCp": 750,
      "KeepMinIvPercentage": 92.0,
      "KeepMinDuplicatePokemon": 2
    },
    "Gyarados": {
      "KeepMinCp": 1200,
      "KeepMinIvPercentage": 90.0,
      "KeepMinDuplicatePokemon": 5
    },
    "Mew": {
      "KeepMinCp": 0,
      "KeepMinIvPercentage": 0.0,
      "KeepMinDuplicatePokemon": 10
    }
  },
  "PokemonToSnipe": {
    "Locations": [
      {
        "Latitude": 38.556807486461118,
        "Longitude": -121.2383794784546
      },
      {
        "Latitude": -33.859019,
        "Longitude": 151.213098
      },
      {
        "Latitude": 47.5014969,
        "Longitude": -122.0959568
      },
      {
        "Latitude": 51.5025343,
        "Longitude": -0.2055027
      }
    ],
    "Pokemon": [
      "Dratini",
      "Magikarp",
      "Eevee",
      "Charmander",
      "Charmeleon",
      "Wartortle",
      "Ivysaur",
      "Bulbasaur",
      "Dragonair",
      "Aerodactyl",
      "Venusaur",
      "Charizard",
      "Blastoise",
      "Nidoqueen",
      "Nidoking",
      "Clefable",
      "Vileplume",
      "Arcanine",
      "Poliwrath",
      "Machamp",
      "Victreebel",
      "Golem",
      "Slowbro",
      "Farfetchd",
      "Muk",
      "Exeggutor",
      "Lickitung",
      "Chansey",
      "Kangaskhan",
      "MrMime",
      "Gyarados",
      "Lapras",
      "Ditto",
      "Vaporeon",
      "Jolteon",
      "Flareon",
      "Porygon",
      "Snorlax",
      "Articuno",
      "Zapdos",
      "Moltres",
      "Dragonite",
      "Mewtwo",
      "Mew"
    ]
  }
}
Please note: no co-ordanites, "DelayBetweenPlayerActions" is default 5000, and new "WalkingSpeedInKilometerPerHour"default is 15.0 but farms slower and with the new unsoftban bot I am not at all worried.

P.S. You will capture many more bulbasaurs when sniping, and God knows what else (missingno!) (I probably should've kept quiet, but this community is great.) PUT COMMA'S AROUND YOUR AUTH USERNAME AND PASSWORD, jeez people.. still love you lazy bastards :D