### PR TITLE
Optimized default RenameTemplate setting

### DIFF
--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -108,7 +108,7 @@ namespace PoGo.NecroBot.CLI
         public bool KeepPokemonsThatCanEvolve = false;
         public bool PrioritizeIvOverCp = true;
         public bool RenameAboveIv = true;
-        public string RenameTemplate = "{0}_{1}";
+        public string RenameTemplate = "{1}_{0}";
         public bool TransferDuplicatePokemon = true;
         public string TranslationLanguageCode = "en";
         public bool UsePokemonToNotCatchFilter = false;


### PR DESCRIPTION
Optimized default RenameTemplate "{0}_{1}"; to "{1}_{0}" 
With this config you can sort your Pokemons with A-Z to sort your pokemons by IV