### PR TITLE
Fix coordinate related things (i.e. sniping) for non-us users

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Windows.Forms;
@@ -22,6 +23,11 @@ namespace PoGo.NecroBot.CLI
     {
         private static void Main(string[] args)
         {
+            CultureInfo culture = CultureInfo.CreateSpecificCulture("en-US");
+
+            CultureInfo.DefaultThreadCurrentCulture = culture;
+            Thread.CurrentThread.CurrentCulture = culture;
+			
             var subPath = "";
             if (args.Length > 0)
                 subPath = args[0];


### PR DESCRIPTION
Since many sites like PokeVision rely on coordinates and other decimals
being seperated with dots and not with comma. For example, coordinates
have to be 41.242 and not 41,242.
Many non-us locales do use a comma for those separations. This commit
sets the locale for the program fixed to en-US which solves the problem.

Signed-off-by: Lyrex <admin@lyrex.net>