### PR TITLE
Functionality to transfer amost all (or all) pokemons at fully evolved state

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -47,16 +47,18 @@ namespace PoGo.NecroBot.Logic
         {
         }
 
-        public TransferFilter(int keepMinCp, float keepMinIvPercentage, int keepMinDuplicatePokemon)
+        public TransferFilter(int keepMinCp, float keepMinIvPercentage, int keepMinDuplicatePokemon, int keepEvolvedDuplicates)
         {
             KeepMinCp = keepMinCp;
             KeepMinIvPercentage = keepMinIvPercentage;
             KeepMinDuplicatePokemon = keepMinDuplicatePokemon;
+            KeepEvolvedDuplicates = keepEvolvedDuplicates;
         }
 
         public int KeepMinCp { get; set; }
         public float KeepMinIvPercentage { get; set; }
         public int KeepMinDuplicatePokemon { get; set; }
+        public int KeepEvolvedDuplicates { get; set; }
     }
 
     public interface ILogicSettings
@@ -73,6 +75,8 @@ namespace PoGo.NecroBot.Logic
         int DelayBetweenPlayerActions { get; }
         bool UsePokemonToNotCatchFilter { get; }
         int KeepMinDuplicatePokemon { get; }
+        int KeepEvolvedDuplicates { get; }
+        bool TransferDuplicateEvolvedPokemon { get; }
         bool PrioritizeIvOverCp { get; }
         int MaxTravelDistanceInMeters { get; }
         bool UseGpxPathing { get; }

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -81,7 +81,11 @@ namespace PoGo.NecroBot.Logic
                 {
                     var settings = pokemonSettings.Single(x => x.PokemonId == p.PokemonId);
                     return settings.CandyToEvolve == 0;
-                }).GroupBy(p => p.PokemonId).Where(g => g.Count() > GetPokemonTransferFilter(g.Key).KeepEvolvedDuplicates).ToList();
+                }).GroupBy(p => p.PokemonId).Where(g =>
+                {
+                    int keepDups = GetPokemonTransferFilter(g.Key).KeepEvolvedDuplicates;
+                    return keepDups > 0 && g.Count() > keepDups;
+                }).ToList();
 
                 notEvolvable.ForEach(g => results.AddRange(g.OrderBy(o => o.Cp).Take(g.Count() - GetPokemonTransferFilter(g.Key).KeepEvolvedDuplicates)));
 

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -104,6 +104,8 @@ namespace PoGo.NecroBot.CLI
         public int MaxTravelDistanceInMeters = 1000;
         public int KeepMinCp = 1250;
         public int KeepMinDuplicatePokemon = 1;
+        public int KeepEvolvedDuplicates = 2;
+        public bool TransferDuplicateEvolvedPokemon = false;
         public float KeepMinIvPercentage = 95;
         public bool KeepPokemonsThatCanEvolve = false;
         public bool PrioritizeIvOverCp = true;
@@ -235,17 +237,17 @@ namespace PoGo.NecroBot.CLI
 
         public Dictionary<PokemonId, TransferFilter> PokemonsTransferFilter = new Dictionary<PokemonId, TransferFilter>
         {
-            {PokemonId.Pidgeotto, new TransferFilter(1500, 90, 1)},
-            {PokemonId.Fearow, new TransferFilter(1500, 90, 2)},
-            {PokemonId.Zubat, new TransferFilter(500, 90, 2)},
-            {PokemonId.Golbat, new TransferFilter(1500, 90, 2)},
-            {PokemonId.Pinsir, new TransferFilter(1500, 95, 2)},
-            {PokemonId.Golduck, new TransferFilter(1350, 95, 2)},
-            {PokemonId.Tentacruel, new TransferFilter(1350, 95, 2)},
-            {PokemonId.Starmie, new TransferFilter(1350, 95, 2)},
-            {PokemonId.Eevee, new TransferFilter(750, 92, 2)},
-            {PokemonId.Gyarados, new TransferFilter(1200, 90, 5)},
-            {PokemonId.Mew, new TransferFilter(0, 0, 10)}
+            {PokemonId.Pidgeotto, new TransferFilter(1500, 90, 1, 2)},
+            {PokemonId.Fearow, new TransferFilter(1500, 90, 2, 2)},
+            {PokemonId.Zubat, new TransferFilter(500, 90, 2, 2)},
+            {PokemonId.Golbat, new TransferFilter(1500, 90, 2, 2)},
+            {PokemonId.Pinsir, new TransferFilter(1500, 95, 2, 2)},
+            {PokemonId.Golduck, new TransferFilter(1350, 95, 2, 2)},
+            {PokemonId.Tentacruel, new TransferFilter(1350, 95, 2, 2)},
+            {PokemonId.Starmie, new TransferFilter(1350, 95, 2, 2)},
+            {PokemonId.Eevee, new TransferFilter(750, 92, 2, 2)},
+            {PokemonId.Gyarados, new TransferFilter(1200, 90, 5, 2)},
+            {PokemonId.Mew, new TransferFilter(0, 0, 10, 2)}
         };
 
         public SnipeSettings PokemonToSnipe = new SnipeSettings
@@ -512,5 +514,7 @@ namespace PoGo.NecroBot.CLI
         public bool StartupWelcomeDelay => _settings.StartupWelcomeDelay;
         public bool SnipeAtPokestops => _settings.SnipeAtPokestops;
         public SnipeSettings PokemonToSnipe => _settings.PokemonToSnipe;
+        public int KeepEvolvedDuplicates => _settings.KeepEvolvedDuplicates;
+        public bool TransferDuplicateEvolvedPokemon => _settings.TransferDuplicateEvolvedPokemon;
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -29,8 +29,8 @@ namespace PoGo.NecroBot.Logic.Tasks
 
             foreach (var duplicatePokemon in duplicatePokemons)
             {
-                bool lessEvolved = duplicatePokemons.Where(p => p.PokemonId == duplicatePokemon.PokemonId).Count() <= (pokemons.Where(ip => ip.PokemonId == duplicatePokemon.PokemonId).Count() - session.LogicSettings.KeepEvolvedDuplicates);
-                bool lowerEvolvedCp = session.Inventory.GetPokemons().Result.Where(p => p.PokemonId == duplicatePokemon.PokemonId).OrderByDescending(p => p.Cp).ElementAt(session.LogicSettings.KeepEvolvedDuplicates - 1).Cp > duplicatePokemon.Cp;
+                bool lessEvolved = session.LogicSettings.TransferDuplicateEvolvedPokemon && duplicatePokemons.Where(p => p.PokemonId == duplicatePokemon.PokemonId).Count() <= (pokemons.Where(ip => ip.PokemonId == duplicatePokemon.PokemonId).Count() - session.LogicSettings.KeepEvolvedDuplicates);
+                bool lowerEvolvedCp = session.LogicSettings.TransferDuplicateEvolvedPokemon && pokemons.Where(p => p.PokemonId == duplicatePokemon.PokemonId).OrderByDescending(p => p.Cp).ElementAt(session.LogicSettings.KeepEvolvedDuplicates - 1).Cp > duplicatePokemon.Cp;
                 if ((duplicatePokemon.Cp >= session.Inventory.GetPokemonTransferFilter(duplicatePokemon.PokemonId).KeepMinCp ||
                     PokemonInfo.CalculatePokemonPerfection(duplicatePokemon) >
                     session.Inventory.GetPokemonTransferFilter(duplicatePokemon.PokemonId).KeepMinIvPercentage) &&

--- a/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/TransferDuplicatePokemonTask.cs
@@ -19,16 +19,24 @@ namespace PoGo.NecroBot.Logic.Tasks
                 await
                     session.Inventory.GetDuplicatePokemonToTransfer(session.LogicSettings.KeepPokemonsThatCanEvolve,
                         session.LogicSettings.PrioritizeIvOverCp,
-                        session.LogicSettings.PokemonsNotToTransfer);
+                        session.LogicSettings.PokemonsNotToTransfer,
+                        session.LogicSettings.TransferDuplicateEvolvedPokemon);
 
             var pokemonSettings = await session.Inventory.GetPokemonSettings();
             var pokemonFamilies = await session.Inventory.GetPokemonFamilies();
+            var pokemonsIE = await session.Inventory.GetPokemons();
+            var pokemons = pokemonsIE.ToList();
 
             foreach (var duplicatePokemon in duplicatePokemons)
             {
-                if (duplicatePokemon.Cp >= session.Inventory.GetPokemonTransferFilter(duplicatePokemon.PokemonId).KeepMinCp ||
+                bool lessEvolved = duplicatePokemons.Where(p => p.PokemonId == duplicatePokemon.PokemonId).Count() <= (pokemons.Where(ip => ip.PokemonId == duplicatePokemon.PokemonId).Count() - session.LogicSettings.KeepEvolvedDuplicates);
+                bool lowerEvolvedCp = session.Inventory.GetPokemons().Result.Where(p => p.PokemonId == duplicatePokemon.PokemonId).OrderByDescending(p => p.Cp).ElementAt(session.LogicSettings.KeepEvolvedDuplicates - 1).Cp > duplicatePokemon.Cp;
+                if ((duplicatePokemon.Cp >= session.Inventory.GetPokemonTransferFilter(duplicatePokemon.PokemonId).KeepMinCp ||
                     PokemonInfo.CalculatePokemonPerfection(duplicatePokemon) >
-                    session.Inventory.GetPokemonTransferFilter(duplicatePokemon.PokemonId).KeepMinIvPercentage)
+                    session.Inventory.GetPokemonTransferFilter(duplicatePokemon.PokemonId).KeepMinIvPercentage) &&
+                    (!session.LogicSettings.TransferDuplicateEvolvedPokemon ||
+                        (!lessEvolved &&
+                        !lowerEvolvedCp)))
                 {
                     continue;
                 }


### PR DESCRIPTION
As for now, this bot might leave you with, for example, 30 of Hypnos, because they have high CP and cannot be evolved anymore. With this change, you would be able to leave only few of them and transfer the rest.
Settings for this allow you to turn it off and on, and set how many pokemons should be left.
Of course you can set how much pokemons should be left, individually for each of them, too.