### PR TITLE
Sniper with automated pokelocation feed

### DIFF
--- a/PoGo.NecroBot.CLI/Program.cs
+++ b/PoGo.NecroBot.CLI/Program.cs
@@ -79,6 +79,8 @@ namespace PoGo.NecroBot.CLI
                 (lat, lng) => session.EventDispatcher.Send(new UpdatePositionEvent {Latitude = lat, Longitude = lng});
 
             machine.AsyncStart(new VersionCheckState(), session);
+            if(session.LogicSettings.UseSnipeLocationServer)
+                SnipePokemonTask.AsyncStart(session);
 
             //Non-blocking key reader
             //This will allow to process console key presses in another code parts

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -31,14 +31,14 @@ namespace PoGo.NecroBot.Logic
         {
         }
 
-        public SnipeSettings(List<Location> locations, List<string> pokemon)
+        public SnipeSettings(List<Location> locations, List<PokemonId> pokemon)
         {
             Locations = locations;
             Pokemon = pokemon;
         }
 
         public List<Location> Locations { get; set; }
-        public List<string> Pokemon { get; set; }
+        public List<PokemonId> Pokemon { get; set; }
     }
 
     public class TransferFilter

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -90,6 +90,9 @@ namespace PoGo.NecroBot.Logic
         string ProfileConfigPath { get; }
         string GeneralConfigPath { get; }
         bool SnipeAtPokestops { get; }
+        string SnipeLocationServer { get; }
+        int SnipeLocationServerPort { get; }
+        bool UseSnipeLocationServer { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -93,6 +93,7 @@ namespace PoGo.NecroBot.Logic
         string SnipeLocationServer { get; }
         int SnipeLocationServerPort { get; }
         bool UseSnipeLocationServer { get; }
+        bool UseTransferIVForSnipe { get; }
         int MinDelayBetweenSnipes { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -93,6 +93,7 @@ namespace PoGo.NecroBot.Logic
         string SnipeLocationServer { get; }
         int SnipeLocationServerPort { get; }
         bool UseSnipeLocationServer { get; }
+        int MinDelayBetweenSnipes { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -314,6 +314,11 @@ namespace PoGo.NecroBot.CLI
                 settings.RenameTemplate = Default.RenameTemplate;
             }
 
+            if(settings.SnipeLocationServer == null)
+            {
+                settings.SnipeLocationServer = Default.SnipeLocationServer;
+            }
+
             settings.ProfilePath = profilePath;
             settings.ProfileConfigPath = profileConfigPath;
             settings.GeneralConfigPath = Path.Combine(Directory.GetCurrentDirectory(), "config");

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -262,12 +262,13 @@ namespace PoGo.NecroBot.CLI
                 new Location(51.5025343,-0.2055027) //Charmender Spot
 
             },
-            Pokemon = new List<string>()
+            Pokemon = new List<PokemonId>()
             {
-                PokemonId.Dratini.ToString(),
-                PokemonId.Magikarp.ToString(),
-                PokemonId.Eevee.ToString(),
-                PokemonId.Charmander.ToString()
+                PokemonId.Dratini,
+                PokemonId.Magikarp,
+                PokemonId.Eevee,
+                PokemonId.Snorlax,
+                PokemonId.Dragonair,
             }
         };
 

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -118,6 +118,7 @@ namespace PoGo.NecroBot.CLI
         public string SnipeLocationServer = "localhost";
         public int SnipeLocationServerPort = 16969;
         public bool UseSnipeLocationServer = false;
+        public int MinDelayBetweenSnipes = 20000;
 
         public List<KeyValuePair<ItemId, int>> ItemRecycleFilter = new List<KeyValuePair<ItemId, int>>
         {
@@ -518,5 +519,6 @@ namespace PoGo.NecroBot.CLI
         public string SnipeLocationServer => _settings.SnipeLocationServer;
         public int SnipeLocationServerPort => _settings.SnipeLocationServerPort;
         public bool UseSnipeLocationServer=> _settings.UseSnipeLocationServer;
+        public int MinDelayBetweenSnipes => _settings.MinDelayBetweenSnipes;
     }
 }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -115,6 +115,9 @@ namespace PoGo.NecroBot.CLI
         public int WebSocketPort = 14251;
         public bool StartupWelcomeDelay = true;
         public bool SnipeAtPokestops = true;
+        public string SnipeLocationServer = "localhost";
+        public int SnipeLocationServerPort = 16969;
+        public bool UseSnipeLocationServer = false;
 
         public List<KeyValuePair<ItemId, int>> ItemRecycleFilter = new List<KeyValuePair<ItemId, int>>
         {
@@ -512,5 +515,8 @@ namespace PoGo.NecroBot.CLI
         public bool StartupWelcomeDelay => _settings.StartupWelcomeDelay;
         public bool SnipeAtPokestops => _settings.SnipeAtPokestops;
         public SnipeSettings PokemonToSnipe => _settings.PokemonToSnipe;
+        public string SnipeLocationServer => _settings.SnipeLocationServer;
+        public int SnipeLocationServerPort => _settings.SnipeLocationServerPort;
+        public bool UseSnipeLocationServer=> _settings.UseSnipeLocationServer;
     }
 }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -118,6 +118,7 @@ namespace PoGo.NecroBot.CLI
         public string SnipeLocationServer = "localhost";
         public int SnipeLocationServerPort = 16969;
         public bool UseSnipeLocationServer = false;
+        public bool UseTransferIVForSnipe = false;
         public int MinDelayBetweenSnipes = 20000;
 
         public List<KeyValuePair<ItemId, int>> ItemRecycleFilter = new List<KeyValuePair<ItemId, int>>
@@ -520,6 +521,7 @@ namespace PoGo.NecroBot.CLI
         public string SnipeLocationServer => _settings.SnipeLocationServer;
         public int SnipeLocationServerPort => _settings.SnipeLocationServerPort;
         public bool UseSnipeLocationServer=> _settings.UseSnipeLocationServer;
+        public bool UseTransferIVForSnipe => _settings.UseTransferIVForSnipe;
         public int MinDelayBetweenSnipes => _settings.MinDelayBetweenSnipes;
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsGPXTask.cs
@@ -35,13 +35,14 @@ namespace PoGo.NecroBot.Logic.Tasks
                 {
                     var trackPoints = track.Segments.ElementAt(0).TrackPoints;
                     var maxTrkPt = trackPoints.Count - 1;
+
                     while (curTrkPt <= maxTrkPt)
                     {
                         var nextPoint = trackPoints.ElementAt(curTrkPt);
                         var distance = LocationUtils.CalculateDistanceInMeters(session.Client.CurrentLatitude,
                             session.Client.CurrentLongitude, Convert.ToDouble(nextPoint.Lat, CultureInfo.InvariantCulture),
                             Convert.ToDouble(nextPoint.Lon, CultureInfo.InvariantCulture));
-
+                        
                         if (distance > 5000)
                         {
                             session.EventDispatcher.Send(new ErrorEvent
@@ -94,11 +95,6 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                             await RecycleItemsTask.Execute(session);
 
-                            if (session.LogicSettings.SnipeAtPokestops)
-                            {
-                                await SnipePokemonTask.Execute(session);
-                            }
-
                             if (session.LogicSettings.EvolveAllPokemonWithEnoughCandy ||
                                 session.LogicSettings.EvolveAllPokemonAboveIv)
                             {
@@ -114,6 +110,11 @@ namespace PoGo.NecroBot.Logic.Tasks
                             {
                                 await RenamePokemonTask.Execute(session);
                             }
+                        }
+
+                        if (session.LogicSettings.SnipeAtPokestops)
+                        {
+                            await SnipePokemonTask.Execute(session);
                         }
 
                         await session.Navigation.HumanPathWalking(trackPoints.ElementAt(curTrkPt),

--- a/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/FarmPokestopsTask.cs
@@ -150,10 +150,6 @@ namespace PoGo.NecroBot.Logic.Tasks
                         await session.Inventory.RefreshCachedInventory();
                     }
                     await RecycleItemsTask.Execute(session);
-                    if (session.LogicSettings.SnipeAtPokestops)
-                    {
-                        await SnipePokemonTask.Execute(session);
-                    }
                     if (session.LogicSettings.EvolveAllPokemonWithEnoughCandy || session.LogicSettings.EvolveAllPokemonAboveIv)
                     {
                         await EvolvePokemonTask.Execute(session);
@@ -166,6 +162,11 @@ namespace PoGo.NecroBot.Logic.Tasks
                     {
                         await RenamePokemonTask.Execute(session);
                     }
+                }
+
+                if (session.LogicSettings.SnipeAtPokestops)
+                {
+                    await SnipePokemonTask.Execute(session);
                 }
             }
         }

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -49,12 +49,26 @@ namespace PoGo.NecroBot.Logic.Tasks
 
         public override string ToString()
         {
-            return uid;
+            return latitude.ToString("0.0000") + ", " + latitude.ToString("0.0000");
         }
 
         public bool Equals(PokemonLocation obj)
         {
-            return latitude == obj.latitude && longitude == obj.longitude;
+            return Math.Abs(latitude - obj.latitude) < 0.0001 && Math.Abs(longitude - obj.longitude) < 0.0001;
+        }
+
+        public override bool Equals(Object obj) // contains calls this here
+        {
+            if (obj == null)
+                return false;
+            
+            PokemonLocation p = obj as PokemonLocation;
+            if ((System.Object)p == null) // no cast available
+            {
+                return false;
+            }
+
+            return Math.Abs(latitude - p.latitude) < 0.0001 && Math.Abs(longitude - p.longitude) < 0.0001;
         }
     }
 

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -101,12 +101,13 @@ namespace PoGo.NecroBot.Logic.Tasks
                         snipeLocations.Add(info);
                     }
                 }
-                catch (SocketException ex)
+                catch (SocketException)
                 {
                     // this is spammed to often. Maybe add it to debug log later
                 }
                 catch (Exception ex)
                 {
+                    // most likely System.IO.IOException
                     session.EventDispatcher.Send(new ErrorEvent { Message = ex.ToString() });
                 }
 

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -54,7 +54,6 @@ namespace PoGo.NecroBot.Logic.Tasks
 
         public bool Equals(PokemonLocation obj)
         {
-            Logging.Logger.Write($"Equals check: {latitude}= {obj.latitude} && {longitude} ={obj.longitude}");
             return latitude == obj.latitude && longitude == obj.longitude;
         }
     }
@@ -94,12 +93,9 @@ namespace PoGo.NecroBot.Logic.Tasks
                         var info = JsonConvert.DeserializeObject<SniperInfo>(line);
 
                         if (snipeLocations.Any(x => 
-                                Math.Abs(x.latitude - info.latitude) < 0.001 && 
-                                Math.Abs(x.longitude - info.longitude) < 0.001)) // we might have different precisions from other sources
-                        {
-                            Logging.Logger.Write($"Equal coords:  {info.latitude} && {info.longitude}");
+                                Math.Abs(x.latitude - info.latitude) < 0.0001 && 
+                                Math.Abs(x.longitude - info.longitude) < 0.0001)) // we might have different precisions from other sources
                             continue;
-                        }
 
                         snipeLocations.RemoveAll(x => DateTime.Now > x.timeStampAdded.AddMinutes(15));
                         snipeLocations.Add(info);

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -115,7 +115,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             }
         }
 
-        private static async Task snipe(ISession session, IEnumerable<int> pokemonIds, double latitude, double longitude)
+        private static async Task snipe(ISession session, IEnumerable<PokemonId> pokemonIds, double latitude, double longitude)
         {
             var currentLatitude = session.Client.CurrentLatitude;
             var currentLongitude = session.Client.CurrentLongitude;
@@ -133,7 +133,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             var mapObjects = session.Client.Map.GetMapObjects().Result;
             var catchablePokemon =
                 mapObjects.MapCells.SelectMany(q => q.CatchablePokemons)
-                    .Where(q => pokemonIds.Contains((int)q.PokemonId))
+                    .Where(q => pokemonIds.Contains(q.PokemonId))
                     .ToList();
 
             await session.Client.Player.UpdatePlayerLocation(currentLatitude, currentLongitude,
@@ -198,9 +198,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 TimeSpan t = (DateTime.Now.ToUniversalTime() - st);
                 var currentTimestamp = t.TotalMilliseconds;
 
-                var pokemonIds =
-                    session.LogicSettings.PokemonToSnipe.Pokemon.Select(
-                        q => Enum.Parse(typeof(PokemonId), q) as PokemonId? ?? PokemonId.Missingno).Select(q => (int)q);
+                var pokemonIds = session.LogicSettings.PokemonToSnipe.Pokemon;
                 
                 if (session.LogicSettings.UseSnipeLocationServer)
                 {
@@ -208,7 +206,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                         !locsVisited.Contains(new PokemonLocation(q.latitude, q.longitude))
                         && !(q.timeStamp != default(DateTime) &&
                                 q.timeStamp > new DateTime(2016) && // make absolutely sure that the server sent a correct datetime
-                                q.timeStamp < DateTime.Now) && (q.id == PokemonId.Missingno || pokemonIds.Contains((int)q.id))).ToList();
+                                q.timeStamp < DateTime.Now) && (q.id == PokemonId.Missingno || pokemonIds.Contains(q.id))).ToList();
 
                     if (locationsToSnipe.Any())
                     {
@@ -230,7 +228,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     var scanResult = SnipeScanForPokemon(location);
 
                     var locationsToSnipe = scanResult.pokemon == null ? new List<PokemonLocation>() : scanResult.pokemon.Where(q =>
-                        pokemonIds.Contains(q.pokemonId)
+                        pokemonIds.Contains((PokemonId)q.pokemonId)
                         && !locsVisited.Contains(q)
                         && q.expiration_time < currentTimestamp
                         && q.is_alive).ToList();

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -52,9 +52,9 @@ namespace PoGo.NecroBot.Logic.Tasks
             return uid;
         }
 
-        public override bool Equals(object obj)
+        public bool Equals(PokemonLocation obj)
         {
-            return this.ToString().Equals(obj.ToString());
+            return latitude == obj.latitude && longitude == obj.longitude;
         }
     }
 
@@ -203,7 +203,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                         !locsVisited.Contains(new PokemonLocation(q.latitude, q.longitude))
                         && !(q.timeStamp != default(DateTime) &&
                                 q.timeStamp > new DateTime(2016) && // make absolutely sure that the server sent a correct datetime
-                                q.timeStamp < DateTime.Now)).ToList();
+                                q.timeStamp < DateTime.Now) && (q.id == PokemonId.Missingno || pokemonIds.Contains((int)q.id))).ToList();
 
                     if (locationsToSnipe.Any())
                     {

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -101,6 +101,10 @@ namespace PoGo.NecroBot.Logic.Tasks
                         snipeLocations.Add(info);
                     }
                 }
+                catch (SocketException ex)
+                {
+                    // this is spammed to often. Maybe add it to debug log later
+                }
                 catch (Exception ex)
                 {
                     session.EventDispatcher.Send(new ErrorEvent { Message = ex.ToString() });

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -54,6 +54,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
         public bool Equals(PokemonLocation obj)
         {
+            Logging.Logger.Write($"Equals check: {latitude}= {obj.latitude} && {longitude} ={obj.longitude}");
             return latitude == obj.latitude && longitude == obj.longitude;
         }
     }
@@ -93,9 +94,12 @@ namespace PoGo.NecroBot.Logic.Tasks
                         var info = JsonConvert.DeserializeObject<SniperInfo>(line);
 
                         if (snipeLocations.Any(x => 
-                                Math.Abs(x.latitude - info.latitude) < 0.0001 && 
-                                Math.Abs(x.longitude - info.longitude) < 0.0001)) // we might have different precisions from other sources
+                                Math.Abs(x.latitude - info.latitude) < 0.001 && 
+                                Math.Abs(x.longitude - info.longitude) < 0.001)) // we might have different precisions from other sources
+                        {
+                            Logging.Logger.Write($"Equal coords:  {info.latitude} && {info.longitude}");
                             continue;
+                        }
 
                         snipeLocations.RemoveAll(x => DateTime.Now > x.timeStampAdded.AddMinutes(15));
                         snipeLocations.Add(info);

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -217,6 +217,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                 if (session.LogicSettings.UseSnipeLocationServer)
                 {
                     var locationsToSnipe = snipeLocations == null ? new List<SniperInfo>() : snipeLocations.Where(q =>
+                        // when UseTransferIVForSnipe=true skip pokemons with unknown iv or if they don't match the TransferFilter/default MinIV
+                        (!session.LogicSettings.UseTransferIVForSnipe || (q.iv > 0 && q.iv < session.Inventory.GetPokemonTransferFilter(q.id).KeepMinIvPercentage)) &&
                         !locsVisited.Contains(new PokemonLocation(q.latitude, q.longitude))
                         && !(q.timeStamp != default(DateTime) &&
                                 q.timeStamp > new DateTime(2016) && // make absolutely sure that the server sent a correct datetime

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -11,9 +11,23 @@ using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Utils;
 using POGOProtos.Enums;
 using POGOProtos.Networking.Responses;
+using System.Net.Sockets;
 
 namespace PoGo.NecroBot.Logic.Tasks
 {
+    public class SniperInfo
+    {
+        public double latitude { get; set; }
+        public double longitude { get; set; }
+        public double iv { get; set; }
+        public DateTime timeStamp { get; set; }
+        public PokemonId id { get; set; }
+        [JsonIgnore]
+        public DateTime timeStampAdded { get; set; } = DateTime.Now;
+        [JsonIgnore]
+        public bool caught { get; set; } = false;
+    }
+
     public class PokemonLocation
     {
         public long id { get; set; }
@@ -49,6 +63,117 @@ namespace PoGo.NecroBot.Logic.Tasks
     public static class SnipePokemonTask
     {
         public static List<PokemonLocation> locsVisited = new List<PokemonLocation>();
+        private static List<SniperInfo> snipeLocations = new List<SniperInfo>();
+
+        public static Task AsyncStart(Session session)
+        {
+            return Task.Run(() => Start(session));
+        }
+        public static async Task Start(Session session)
+        {
+            while(true)
+            {
+                try { 
+                    TcpClient lClient = new TcpClient();
+                    lClient.Connect(session.LogicSettings.SnipeLocationServer, session.LogicSettings.SnipeLocationServerPort);
+
+                    var sr = new StreamReader(lClient.GetStream());
+
+                    while (lClient.Connected)
+                    {
+                        var line = sr.ReadLine();
+                        if (line == null)
+                            throw new Exception("Unable to ReadLine from sniper socket");
+
+                        var info = JsonConvert.DeserializeObject<SniperInfo>(line);
+                        if (snipeLocations.Any(x => 
+                                Math.Abs(x.latitude - info.latitude) < 0.0001 && 
+                                Math.Abs(x.longitude - info.longitude) < 0.0001)) // we might have different precisions from other sources
+                            continue;
+                        snipeLocations.RemoveAll(x => DateTime.Now > x.timeStampAdded.AddMinutes(15));
+                        snipeLocations.Add(info);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    session.EventDispatcher.Send(new ErrorEvent { Message = ex.ToString() });
+                }
+
+                await Task.Delay(5000);
+            }
+        }
+
+        private static async Task snipe(ISession session, IEnumerable<int> pokemonIds, double latitude, double longitude)
+        {
+            var currentLatitude = session.Client.CurrentLatitude;
+            var currentLongitude = session.Client.CurrentLongitude;
+
+            await
+                session.Client.Player.UpdatePlayerLocation(latitude,
+                    longitude, session.Client.CurrentAltitude);
+
+            session.EventDispatcher.Send(new UpdatePositionEvent()
+            {
+                Longitude = longitude,
+                Latitude = latitude
+            });
+
+            var mapObjects = session.Client.Map.GetMapObjects().Result;
+            var catchablePokemon =
+                mapObjects.MapCells.SelectMany(q => q.CatchablePokemons)
+                    .Where(q => pokemonIds.Contains((int)q.PokemonId))
+                    .ToList();
+
+            await session.Client.Player.UpdatePlayerLocation(currentLatitude, currentLongitude,
+                        session.Client.CurrentAltitude);
+
+            foreach (var pokemon in catchablePokemon)
+            {
+                await session.Client.Player.UpdatePlayerLocation(latitude, longitude, session.Client.CurrentAltitude);
+
+                var encounter = session.Client.Encounter.EncounterPokemon(pokemon.EncounterId, pokemon.SpawnPointId).Result;
+
+                await session.Client.Player.UpdatePlayerLocation(currentLatitude, currentLongitude, session.Client.CurrentAltitude);
+
+                if (encounter.Status == EncounterResponse.Types.Status.EncounterSuccess)
+                {
+                    session.EventDispatcher.Send(new UpdatePositionEvent()
+                    {
+                        Latitude = currentLatitude,
+                        Longitude = currentLongitude
+                    });
+
+                    await CatchPokemonTask.Execute(session, encounter, pokemon);
+                }
+                else if (encounter.Status == EncounterResponse.Types.Status.PokemonInventoryFull)
+                {
+                    session.EventDispatcher.Send(new WarnEvent
+                    {
+                        Message =
+                            session.Translation.GetTranslation(
+                                Common.TranslationString.InvFullTransferManually)
+                    });
+                }
+                else
+                {
+                    session.EventDispatcher.Send(new WarnEvent
+                    {
+                        Message =
+                            session.Translation.GetTranslation(
+                                Common.TranslationString.EncounterProblem, encounter.Status)
+                    });
+                }
+
+                if (
+                    !Equals(catchablePokemon.ElementAtOrDefault(catchablePokemon.Count() - 1),
+                        pokemon))
+                {
+                    await Task.Delay(session.LogicSettings.DelayBetweenPokemonCatch);
+                }
+            }
+
+            await Task.Delay(session.LogicSettings.DelayBetweenPlayerActions);
+        }
 
         public static async Task Execute(ISession session)
         {
@@ -58,16 +183,31 @@ namespace PoGo.NecroBot.Logic.Tasks
                 TimeSpan t = (DateTime.Now.ToUniversalTime() - st);
                 var currentTimestamp = t.TotalMilliseconds;
 
+                var pokemonIds =
+                    session.LogicSettings.PokemonToSnipe.Pokemon.Select(
+                        q => Enum.Parse(typeof(PokemonId), q) as PokemonId? ?? PokemonId.Missingno).Select(q => (int)q);
+
+                if(session.LogicSettings.UseSnipeLocationServer)
+                {
+                    foreach(var location in snipeLocations)
+                    {
+                        if (location.caught == true || (location.timeStamp != default(DateTime) &&
+                            location.timeStamp > new DateTime(2016) && // make absolutely sure that the server sent a correct datetime
+                            location.timeStamp < DateTime.Now))
+                            continue; // expired
+
+                        session.EventDispatcher.Send(new SnipeScanEvent() { Bounds = new Location(location.latitude, location.longitude) });
+
+                        await snipe(session, pokemonIds, location.latitude, location.longitude);
+                        location.caught = true;
+                    }
+                } else
+
                 foreach (var location in session.LogicSettings.PokemonToSnipe.Locations)
                 {
                     session.EventDispatcher.Send(new SnipeScanEvent() { Bounds = location });
 
                     var scanResult = SnipeScanForPokemon(location);
-
-                    var pokemonIds =
-                        session.LogicSettings.PokemonToSnipe.Pokemon.Select(
-                            q => Enum.Parse(typeof(PokemonId), q) as PokemonId? ?? PokemonId.Missingno).Select(q => (int)q);
-
 
                     var locationsToSnipe = scanResult.pokemon == null ? new List<PokemonLocation>() : scanResult.pokemon.Where(q =>
                         pokemonIds.Contains(q.pokemonId)
@@ -81,74 +221,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                         {
                             locsVisited.Add(pokemonLocation);
 
-                            var currentLatitude = session.Client.CurrentLatitude;
-                            var currentLongitude = session.Client.CurrentLongitude;
-
-                            await
-                                session.Client.Player.UpdatePlayerLocation(pokemonLocation.latitude,
-                                    pokemonLocation.longitude, session.Client.CurrentAltitude);
-
-                            session.EventDispatcher.Send(new UpdatePositionEvent()
-                            {
-                                Longitude = pokemonLocation.longitude,
-                                Latitude = pokemonLocation.latitude
-                            });
-
-                            var mapObjects = session.Client.Map.GetMapObjects().Result;
-                            var catchablePokemon =
-                                mapObjects.MapCells.SelectMany(q => q.CatchablePokemons)
-                                    .Where(q => pokemonIds.Contains((int)q.PokemonId))
-                                    .ToList();
-
-                            await session.Client.Player.UpdatePlayerLocation(currentLatitude, currentLongitude,
-                                        session.Client.CurrentAltitude);
-
-                            foreach (var pokemon in catchablePokemon)
-                            {
-                                await session.Client.Player.UpdatePlayerLocation(pokemonLocation.latitude, pokemonLocation.longitude, session.Client.CurrentAltitude);
-
-                                var encounter = session.Client.Encounter.EncounterPokemon(pokemon.EncounterId, pokemon.SpawnPointId).Result;
-
-                                await session.Client.Player.UpdatePlayerLocation(currentLatitude, currentLongitude, session.Client.CurrentAltitude);
-
-                                if (encounter.Status == EncounterResponse.Types.Status.EncounterSuccess)
-                                {
-                                    session.EventDispatcher.Send(new UpdatePositionEvent()
-                                    {
-                                        Latitude = currentLatitude,
-                                        Longitude = currentLongitude
-                                    });
-
-                                    await CatchPokemonTask.Execute(session, encounter, pokemon);
-                                }
-                                else if (encounter.Status == EncounterResponse.Types.Status.PokemonInventoryFull)
-                                {
-                                    session.EventDispatcher.Send(new WarnEvent
-                                    {
-                                        Message =
-                                            session.Translation.GetTranslation(
-                                                Common.TranslationString.InvFullTransferManually)
-                                    });
-                                }
-                                else
-                                {
-                                    session.EventDispatcher.Send(new WarnEvent
-                                    {
-                                        Message =
-                                            session.Translation.GetTranslation(
-                                                Common.TranslationString.EncounterProblem, encounter.Status)
-                                    });
-                                }
-
-                                if (
-                                    !Equals(catchablePokemon.ElementAtOrDefault(catchablePokemon.Count() - 1),
-                                        pokemon))
-                                {
-                                    await Task.Delay(session.LogicSettings.DelayBetweenPokemonCatch);
-                                }
-                            }
-
-                            await Task.Delay(session.LogicSettings.DelayBetweenPlayerActions);
+                            await snipe(session, pokemonIds, pokemonLocation.latitude, pokemonLocation.longitude);
                         }
                     }
                     else


### PR DESCRIPTION
See for yourself: [Image](https://dl.dropboxusercontent.com/u/28069358/wow.jpg)

The client connects to an open source server made by @Ilses and me:
https://github.com/5andr0/PogoLocationFeeder/tree/master/PogoLocationFeeder

Right now it is crawling new pokemon locations from the discord channel #sniping 
and sending them via json to the client. This can be improved to be a pokevision scraper etc

```
  "SnipeAtPokestops": true,
  "SnipeLocationServer": "localhost",
  "SnipeLocationServerPort": 16969,
  "UseSnipeLocationServer": true,
  "UseTransferIVForSnipe": false,
  "MinDelayBetweenSnipes": 20000,
```

There's a major bug in FarmPokestopsGPXTask.cs
where `while (pokestopList.Any())` is never true because pokestops are already @ cooldown because of UseNearbyPokestopsTask. So all the calls in the loop are never executed (or 1 in 100). That's why i had to move the SnipePokemonTask call out which is then called more often. So i added the MinDelayBetweenSnipes.

More info on our wiki page: [PogoLocationFeeder Wiki](https://github.com/5andr0/PogoLocationFeeder/wiki)

Quick tutorial:
- connect your discord account to the [NecroBot server](https://discord.gg/VsVrjgr)
- start the PogoLocationFeeder to generate the config.json and enter your discord logins
- start it again and run your necrobots. now wait until someone posts into #sniping 

Can we find somebody to host the feeder so everybody can connect via ip+port?

Please help me to improve the feeder project. Todo: location database with continuous pokevision scraping. Or anything that helps to get locations.

Make sure you filled your PokemonToSnipe array:
```
"Pokemon": [
      "Dratini",
      "Magikarp",
      "Kangaskhan",
      "Eevee",
      "Charmander",
      "Snorlax",
      "Chansey",
      "Exeggutor",
      "Aerodactyl",
      "Vaporeon",
      "MrMime",
      "Magmar",
      "Dragonite",
      "Raichu",
      "Venusaur",
      "Slowbro",
      "Porygon",
      "Farfetchd",
      "Poliwrath",
      "Dragonair",
      "Charizard",
      "Blastoise",
      "Muk",
      "Gyarados",
      "Arcanine",
      "Machamp"
    ]
```