### PR TITLE
Set snipe timeout to avoid waste of time.

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -172,6 +172,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 var request = WebRequest.CreateHttp(uri);
                 request.Accept = "application/json";
                 request.Method = "GET";
+                request.Timeout = 1000;
 
                 var resp = request.GetResponse();
                 var reader = new StreamReader(resp.GetResponseStream());


### PR DESCRIPTION
Set snipe timeout to avoid waste of time, especially when network is unstable.