### PR TITLE
Culture fix/hack in SnipePokemonTasks.cs

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -280,7 +280,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             ScanResult scanResult;
             try
             {
-                var request = WebRequest.CreateHttp(uri);
+                var request = WebRequest.CreateHttp(uri.Replace(',', '.'));
                 request.Accept = "application/json";
                 request.Method = "GET";
                 request.Timeout = 1000;


### PR DESCRIPTION
Because of Culture settings/differences, numbers and fractions may be separated by a comma instead of a dot.