### PR TITLE
error

### DIFF
--- a/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
+++ b/PoGo.NecroBot.Logic/PoGo.NecroBot.Logic.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Device" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/PoGo.NecroBot.Logic/State/VersionCheckState.cs
+++ b/PoGo.NecroBot.Logic/State/VersionCheckState.cs
@@ -1,10 +1,12 @@
 ﻿#region using directives
 
 using System;
+using System.IO;
+using System.IO.Compression;
 using System.Net;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using PoGo.NecroBot.Logic.Event;
+using PoGo.NecroBot.Logic.Logging;
 
 #endregion
 
@@ -13,28 +15,83 @@ namespace PoGo.NecroBot.Logic.State
     public class VersionCheckState : IState
     {
         public static string VersionUri =
-            "https://raw.githubusercontent.com/NecronomiconCoding/Pokemon-Go-Bot/master/PokemonGo.RocketAPI/Properties/AssemblyInfo.cs";
+            "https://raw.githubusercontent.com/NecronomiconCoding/NecroBot/master/PoGo.NecroBot.Logic/Properties/AssemblyInfo.cs";
+
+        public static string LatestReleaseApi =
+            "https://api.github.com/repos/NecronomiconCoding/NecroBot/releases/latest";
+
+        public static bool AutoUpdate = true; //TODO: read from clientsettings
 
         public IState Execute(Context ctx, StateMachine machine)
         {
-            if (IsLatest())
-            {
-                machine.Fire(new NoticeEvent
-                {
-                    Message =
-                        "Awesome! You have already got the newest version! " +
-                        Assembly.GetExecutingAssembly().GetName().Version
-                });
-            }
-            else
-            {
-                machine.Fire(new WarnEvent
-                {
-                    Message = "There is a new Version available: https://github.com/NecronomiconCoding/Pokemon-Go-Bot"
-                });
-            }
+            CleanupOldFiles();
 
-            return new LoginState();
+            if (IsLatest())
+                //has the newest version NOTE: NOT YET IMPLEMENTED. rest of the code works, just need to check current version against latest
+            {
+                Logger.Write("Using newest Release of NecroBot");
+                return new LoginState();
+            }
+            Logger.Write(AutoUpdate
+                ? "AutoUpdate is enabled, please wait for the bot to begin updating."
+                : "AutoUpdate is disabled. Get the latest release from:\n https://github.com/NecronomiconCoding/NecroBot/releases");
+
+            //TODO: change constant URL to latest Release url provided by the API page (see latestReleaseAPI a few lines up)
+            const string url = "https://github.com/NecronomiconCoding/NecroBot/releases/download/v0.1.5/";
+            const string zipName = "Release.zip";
+            const string downloadLink = url + zipName;
+            var baseDir = new DirectoryInfo(Directory.GetCurrentDirectory());
+            var downloadFilePath = baseDir + "\\" + zipName;
+            var tempPath = baseDir + "\\tmp";
+
+
+            if (DownloadFile(downloadLink, downloadFilePath))
+            {
+                if (UnpackFile(downloadFilePath, tempPath))
+                {
+                    var extractedDir = tempPath + "\\Release";
+                    var destinationDir = baseDir + "\\";
+                    if (MoveAllFiles(extractedDir, destinationDir))
+                    {
+
+                    }
+                }
+            }
+            CleanupOldFiles(); //cleansup most of the .old files that were created when the bot updated
+            Environment.Exit(0);
+            return null;
+        }
+
+        public static void CleanupOldFiles()
+        {
+            var di = new DirectoryInfo(Directory.GetCurrentDirectory());
+            var files = di.GetFiles("*.old");
+            foreach (var file in files)
+                try
+                {
+                    //Logger.Write($"\nDEBUG: Old file found: {file.FullName}");
+                    File.Delete(file.FullName);
+                }
+                catch
+                {
+                    // ignored
+                }
+        }
+
+        public static bool DownloadFile(string url, string dest)
+        {
+            using (var client = new WebClient())
+            {
+                try
+                {
+                    client.DownloadFile(url, dest);
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+                return true;
+            }
         }
 
         private static string DownloadServerVersion()
@@ -45,7 +102,8 @@ namespace PoGo.NecroBot.Logic.State
             }
         }
 
-        public bool IsLatest()
+
+        public bool IsLatest() //TODO: actually use this function
         {
             try
             {
@@ -68,6 +126,60 @@ namespace PoGo.NecroBot.Logic.State
             }
 
             return false;
+        }
+
+        public static bool MoveAllFiles(string sourceFolder, string destFolder)
+        {
+            if (!Directory.Exists(destFolder))
+                Directory.CreateDirectory(destFolder);
+
+            var oldfiles = Directory.GetFiles(destFolder);
+            foreach (var old in oldfiles)
+            {
+                File.Move(old, old + ".old");
+            }
+
+            try
+            {
+                var files = Directory.GetFiles(sourceFolder);
+                foreach (var file in files)
+                {
+                    var name = Path.GetFileName(file);
+                    if (name == null) continue;
+                    var dest = Path.Combine(destFolder, name);
+                    File.Copy(file, dest, true);
+                }
+
+                var folders = Directory.GetDirectories(sourceFolder);
+
+                foreach (var folder in folders)
+                {
+                    var name = Path.GetFileName(folder);
+                    if (name == null) continue;
+                    var dest = Path.Combine(destFolder, name);
+                    MoveAllFiles(folder, dest);
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
+        }
+
+        public static bool UnpackFile(string sourceTarget, string destPath)
+        {
+            var source = sourceTarget;
+            var dest = destPath;
+            try
+            {
+                ZipFile.ExtractToDirectory(source, dest);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
[18:47:31] (ERROR) System.Threading.Tasks.TaskCanceledException: Úkol byl zrušen.
   v System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   v System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   v PokemonGo.RocketAPI.Extensions.HttpClientExtensions.<PostProto>d__1`1.MoveNext() v D:\Dev\NecroBot\FeroxRev\PokemonGo.RocketAPI\Extensions\HttpClientExtensions.cs:řádek 61
--- Konec trasování zásobníku z předchozího místa, ze kterého byla vyvolána výjimka ---
   v System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   v System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   v System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   v PokemonGo.RocketAPI.Extensions.HttpClientExtensions.<PostProtoPayload>d__0`2.MoveNext() v D:\Dev\NecroBot\FeroxRev\PokemonGo.RocketAPI\Extensions\HttpClientExtensions.cs:řádek 39
--- Konec trasování zásobníku z předchozího místa, ze kterého byla vyvolána výjimka ---
   v System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   v System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   v System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   v PokemonGo.RocketAPI.Rpc.BaseRpc.<PostProtoPayload>d__7`2.MoveNext() v D:\Dev\NecroBot\FeroxRev\PokemonGo.RocketAPI\Rpc\BaseRpc.cs:řádek 0
--- Konec trasování zásobníku z předchozího místa, ze kterého byla vyvolána výjimka ---
   v System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   v System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   v System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   v PokemonGo.RocketAPI.Rpc.Player.<UpdatePlayerLocation>d__1.MoveNext() v D:\Dev\NecroBot\FeroxRev\PokemonGo.RocketAPI\Rpc\Player.cs:řádek 40
--- Konec trasování zásobníku z předchozího místa, ze kterého byla vyvolána výjimka ---
   v System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   v System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   v System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   v System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
   v PoGo.NecroBot.Logic.Navigation.<HumanLikeWalking>d__3.MoveNext() v D:\Dev\NecroBot\PoGo.NecroBot.Logic\Navigation.cs:řádek 78
--- Konec trasování zásobníku z předchozího místa, ze kterého byla vyvolána výjimka ---
   v System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   v System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   v System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   v System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd(Task task)
   v PoGo.NecroBot.Logic.Tasks.FarmPokestopsTask.<Execute>d__1.MoveNext() v D:\Dev\NecroBot\PoGo.NecroBot.Logic\Tasks\FarmPokestopsTask.cs:řádek 77
--- Konec trasování zásobníku z předchozího místa, ze kterého byla vyvolána výjimka ---
   v System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   v System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   v System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   v PoGo.NecroBot.Logic.State.FarmState.<Execute>d__0.MoveNext() v D:\Dev\NecroBot\PoGo.NecroBot.Logic\State\FarmState.cs:řádek 42
--- Konec trasování zásobníku z předchozího místa, ze kterého byla vyvolána výjimka ---
   v System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   v System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   v System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   v PoGo.NecroBot.Logic.State.StateMachine.<Start>d__4.MoveNext() v D:\Dev\NecroBot\PoGo.NecroBot.Logic\State\StateMachine.cs:řádek 35
[18:47:31] (INFO) Logging in using Google