### PR TITLE
Added config option: "KeepEvolvablesOnlyIfOnEvolutionList"

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -67,6 +67,7 @@ namespace PoGo.NecroBot.Logic
         double WalkingSpeedInKilometerPerHour { get; }
         bool EvolveAllPokemonWithEnoughCandy { get; }
         bool KeepPokemonsThatCanEvolve { get; }
+        bool KeepEvolvablesOnlyIfOnEvolutionList { get; }
         bool TransferDuplicatePokemon { get; }
         bool UseEggIncubators { get; }
         int DelayBetweenPokemonCatch { get; }

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -91,8 +91,16 @@ namespace PoGo.NecroBot.Logic
                     if (settings.CandyToEvolve > 0)
                     {
                         var amountPossible = familyCandy.Candy_ /settings.CandyToEvolve;
-                        if (amountPossible > amountToSkip)
-                            amountToSkip = amountPossible;
+                        if (_logicSettings.KeepEvolvablesOnlyIfOnEvolutionList)
+                        {
+                            if (amountPossible > amountToSkip && _logicSettings.PokemonsToEvolve.Contains(pokemon.Key))
+                                amountToSkip = amountPossible;
+                        }
+                        else
+                        {
+                            if (amountPossible > amountToSkip)
+                                amountToSkip = amountPossible;
+                        }
                     }
 
                     if (prioritizeIVoverCp)

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -122,6 +122,7 @@ namespace PoGo.NecroBot.CLI
         public int KeepMinDuplicatePokemon = 1;
         public float KeepMinIvPercentage = 95;
         public bool KeepPokemonsThatCanEvolve = false;
+        public bool KeepEvolvablesOnlyIfOnEvolutionList = false;
         public bool PrioritizeIvOverCp = true;
         public bool RenameAboveIv = true;
         public string RenameTemplate = "{1}_{0}";
@@ -521,6 +522,7 @@ namespace PoGo.NecroBot.CLI
         public double WalkingSpeedInKilometerPerHour => _settings.WalkingSpeedInKilometerPerHour;
         public bool EvolveAllPokemonWithEnoughCandy => _settings.EvolveAllPokemonWithEnoughCandy;
         public bool KeepPokemonsThatCanEvolve => _settings.KeepPokemonsThatCanEvolve;
+        public bool KeepEvolvablesOnlyIfOnEvolutionList => _settings.KeepEvolvablesOnlyIfOnEvolutionList;
         public bool TransferDuplicatePokemon => _settings.TransferDuplicatePokemon;
         public bool UseEggIncubators => _settings.UseEggIncubators;
         public int DelayBetweenPokemonCatch => _settings.DelayBetweenPokemonCatch;


### PR DESCRIPTION
Added config option: "KeepEvolvablesOnlyIfOnEvolutionList"
Defaults to false.
If "KeepPokemonsThatCanEvolve" is true, and
"KeepEvolvablesOnlyIfOnEvolutionList" is also true, the bot will NOT
keep pokemon it has enough candy to evolve, unless they are on the
"PokemonsToEvolve" list.