### PR TITLE
Simple IV calculation.

### DIFF
--- a/PoGo.NecroBot.Logic/PoGoUtils/PokemonInfo.cs
+++ b/PoGo.NecroBot.Logic/PoGoUtils/PokemonInfo.cs
@@ -78,7 +78,7 @@ namespace PoGo.NecroBot.Logic.PoGoUtils
         public static double CalculatePokemonPerfection(PokemonData poke)
         {
             if (Math.Abs(poke.CpMultiplier + poke.AdditionalCpMultiplier) <= 0)
-                return (poke.IndividualAttack*2 + poke.IndividualDefense + poke.IndividualStamina)/(4.0*15.0)*100.0;
+                return (poke.IndividualAttack + poke.IndividualDefense + poke.IndividualStamina)/(45.0)*100.0;
 
             GetBaseStats(poke.PokemonId);
             var maxCp = CalculateMaxCpMultiplier(poke);


### PR DESCRIPTION
Calculate IV the way all IV calculators on the Internet do: ATK+STA+DEF/45*100.
I could list a countless list of IV calculators here, most of them from r/thesilphroad and r/pokemongodev and all of them use this formula.
Before the Bot was displaying sorted by IV list of pokemon on the start everyone was using 3rd party tools for calculating IV.
Everyone was wondering why so many 86-90 IV pokemons were not transfered when bot was set to transfer pokes under 90 IV.
That's exactly why, because of the weird formula is using the IV% is artificialy increased by up to 3.5%.