### PR TITLE
Add settings for throw accuracy and spin to humanize pokemon catching

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -101,6 +101,9 @@ namespace PoGo.NecroBot.Logic
         int TotalAmountOfPokebalsToKeep { get; }
         int TotalAmountOfPotionsToKeep { get; }
         int TotalAmountOfRevivesToKeep { get; }
+        double ThrowMaxAccuracy { get; }
+        double ThrowMinAccuracy { get; }
+        double ThrowSpinRatio { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -142,6 +142,9 @@ namespace PoGo.NecroBot.CLI
         public int TotalAmountOfPokebalsToKeep = 150;
         public int TotalAmountOfPotionsToKeep = 100;
         public int TotalAmountOfRevivesToKeep = 50;
+        public double ThrowMaxAccuracy = 1.95;
+        public double ThrowMinAccuracy = 0.1;
+        public double ThrowSpinRatio = 0.3;
 
 
         public List<KeyValuePair<ItemId, int>> ItemRecycleFilter = new List<KeyValuePair<ItemId, int>>
@@ -390,6 +393,21 @@ namespace PoGo.NecroBot.CLI
                 settings.SnipeLocationServer = Default.SnipeLocationServer;
             }
 
+            if (settings.ThrowMaxAccuracy == 0.0)
+            {
+                settings.ThrowMaxAccuracy = 1.95;
+            }
+
+            if (settings.ThrowMinAccuracy == 0.0)
+            {
+                settings.ThrowMinAccuracy = 0.5;
+            }
+
+            if (settings.ThrowSpinRatio == 0.0)
+            {
+                settings.ThrowSpinRatio = 0.5;
+            }
+
             settings.ProfilePath = profilePath;
             settings.ProfileConfigPath = profileConfigPath;
             settings.GeneralConfigPath = Path.Combine(Directory.GetCurrentDirectory(), "config");
@@ -605,5 +623,8 @@ namespace PoGo.NecroBot.CLI
         public int TotalAmountOfPokebalsToKeep => _settings.TotalAmountOfPokebalsToKeep;
         public int TotalAmountOfPotionsToKeep => _settings.TotalAmountOfPotionsToKeep;
         public int TotalAmountOfRevivesToKeep => _settings.TotalAmountOfRevivesToKeep;
+        public double ThrowMaxAccuracy => _settings.ThrowMaxAccuracy;
+        public double ThrowMinAccuracy => _settings.ThrowMinAccuracy;
+        public double ThrowSpinRatio => _settings.ThrowSpinRatio;
     }
 }


### PR DESCRIPTION
After some testing, I found that the CatchPokemon API's final 3 parameters seem to do the following:

normalizedRecticleSize: value from ~0.1 to ~1.95 which determines the quality of the throw.  Low values will have high escape rates, middle values will trigger a "Nice" catch, and high values a "Great" or "Excellent" one.

spinModifier:  Although it's a double, it appears to be a boolean.  If this value is 0, the ball will not have a spin bonus, otherwise it will.

normalizedHitPos:  Can't seem to figure out what this one does -- any value other than 1 triggers CatchError as far as I can tell, but needs further testing.

This pull request uses this information to allow for setting these values, and defaults the accuracy of the throw to 0.5 to 1.95 with a uniform distribution.  It also sets a 50% rate for the Spin Throw.

This pull will (by default) drastically reduce Exp gain from Pokemon catching, but will cause the bot to look less like a bot.