### PR TITLE
Simplify login config

### DIFF
--- a/PoGo.NecroBot.CLI/Config/Translations/translation.es.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.es.json
@@ -363,11 +363,11 @@
     },
     {
       "Key": "missingCredentialsGoogle",
-      "Value": "Es necesario rellenar GoogleUsername y GooglePassword en auth.json!"
+      "Value": "Es necesario rellenar Username y Password en auth.json!"
     },
     {
       "Key": "missingCredentialsPtc",
-      "Value": "Es necesario rellenar PtcUsername y PtcPassword en auth.json!"
+      "Value": "Es necesario rellenar Username y Password en auth.json!"
     },
     {
       "Key": "snipeScan",

--- a/PoGo.NecroBot.CLI/Config/Translations/translation.id.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.id.json
@@ -362,11 +362,11 @@
     },
     {
       "Key": "missingCredentialsGoogle",
-      "Value": "Anda perlu mengisi GoogleUsername dan GooglePassword di auth.json!"
+      "Value": "Anda perlu mengisi Username dan Password di auth.json!"
     },
     {
       "Key": "missingCredentialsPtc",
-      "Value": "Anda perlu mengisi PtcUsername dan PtcPassword di auth.json!"
+      "Value": "Anda perlu mengisi Username dan Password di auth.json!"
     },
     {
       "Key": "snipeScan",

--- a/PoGo.NecroBot.CLI/Config/Translations/translation.it.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.it.json
@@ -366,11 +366,11 @@
     },
     {
       "Key": "missingCredentialsGoogle",
-      "Value": "Devi riempire i campi GoogleUsername e GooglePassword  nel file auth.json!"
+      "Value": "Devi riempire i campi Username e Password  nel file auth.json!"
     },
     {
       "Key": "missingCredentialsPtc",
-      "Value": "Devi riempire i campi PtcUsername e PtcPassword nel file auth.json!"
+      "Value": "Devi riempire i campi Username e Password nel file auth.json!"
     },
     {
       "Key": "snipeScan",

--- a/PoGo.NecroBot.CLI/Config/Translations/translation.pl.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.pl.json
@@ -362,11 +362,11 @@
     },
     {
       "Key": "missingCredentialsGoogle",
-      "Value": "Proszę wypełnić GoogleUsername oraz GooglePassword w auth.json!"
+      "Value": "Proszę wypełnić Username oraz Password w auth.json!"
     },
     {
       "Key": "missingCredentialsPtc",
-      "Value": "Proszę wypełnić PtcUsername oraz PtcPassword w auth.json!"
+      "Value": "Proszę wypełnić Username oraz Password w auth.json!"
     },
     {
       "Key": "snipeScan",

--- a/PoGo.NecroBot.CLI/Config/Translations/translation.pt-br.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.pt-br.json
@@ -362,11 +362,11 @@
     },
     {
       "Key": "missingCredentialsGoogle",
-      "Value": "Você precisa informar o GoogleUsername e GooglePassword no arquivo auth.json!"
+      "Value": "Você precisa informar o Username e Password no arquivo auth.json!"
     },
     {
       "Key": "missingCredentialsPtc",
-      "Value": "Você precisa informar o PtcUsername e PtcPassword no arquivo auth.json!"
+      "Value": "Você precisa informar o Username e Password no arquivo auth.json!"
     },
     {
       "Key": "snipeScan",

--- a/PoGo.NecroBot.CLI/Config/Translations/translation.pt-pt.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.pt-pt.json
@@ -362,11 +362,11 @@
     },
     {
       "Key": "missingCredentialsGoogle",
-      "Value": "Você precisa informar o GoogleUsername e GooglePassword no arquivo auth.json!"
+      "Value": "Você precisa informar o Username e Password no arquivo auth.json!"
     },
     {
       "Key": "missingCredentialsPtc",
-      "Value": "Você precisa informar o PtcUsername e PtcPassword no arquivo auth.json!"
+      "Value": "Você precisa informar o Username e Password no arquivo auth.json!"
     },
     {
       "Key": "snipeScan",

--- a/PoGo.NecroBot.CLI/Config/Translations/translation.ru_RU.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.ru_RU.json
@@ -369,11 +369,11 @@
     },
     {
       "Key": "missingCredentialsGoogle",
-      "Value": "Вам нужно заполнить настройки GoogleUsername и GooglePassword в auth.json!"
+      "Value": "Вам нужно заполнить настройки Username и Password в auth.json!"
     },
     {
       "Key": "missingCredentialsPtc",
-      "Value": "Вам нужно заполнить настройки PtcUsername и PtcPassword в auth.json!"
+      "Value": "Вам нужно заполнить настройки Username и Password в auth.json!"
     },
     {
       "Key": "snipeScan",

--- a/PoGo.NecroBot.CLI/Config/Translations/translation.tr.json
+++ b/PoGo.NecroBot.CLI/Config/Translations/translation.tr.json
@@ -362,11 +362,11 @@
     },
     {
       "Key": "missingCredentialsGoogle",
-      "Value": "\"auth.json\" dosyasına GoogleUsername ve GooglePassword değerlerini girmen gerek!"
+      "Value": "\"auth.json\" dosyasına Username ve Password değerlerini girmen gerek!"
     },
     {
       "Key": "missingCredentialsPtc",
-      "Value": "\"auth.json\" dosyasına PtcUsername ve PtcPassword değerlerini girmen gerek!"
+      "Value": "\"auth.json\" dosyasına Username ve Password değerlerini girmen gerek!"
     },
     {
       "Key": "snipeScan",

--- a/PoGo.NecroBot.Logic/Common/ApiFailureStrategy.cs
+++ b/PoGo.NecroBot.Logic/Common/ApiFailureStrategy.cs
@@ -49,7 +49,7 @@ namespace PoGo.NecroBot.Logic.Common
                 case AuthType.Ptc:
                     try
                     {
-                        await _session.Client.Login.DoPtcLogin(_session.Settings.PtcUsername, _session.Settings.PtcPassword);
+                        await _session.Client.Login.DoPtcLogin(_session.Settings.Username, _session.Settings.Password);
                     }
                     catch (AggregateException ae)
                     {
@@ -57,7 +57,7 @@ namespace PoGo.NecroBot.Logic.Common
                     }
                     break;
                 case AuthType.Google:
-                    await _session.Client.Login.DoGoogleLogin(_session.Settings.GoogleUsername, _session.Settings.GooglePassword);
+                    await _session.Client.Login.DoGoogleLogin(_session.Settings.Username, _session.Settings.Password);
                     break;
                 default:
                     _session.EventDispatcher.Send(new ErrorEvent { Message = _session.Translation.GetTranslation(Common.TranslationString.WrongAuthType) });

--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -220,8 +220,8 @@ namespace PoGo.NecroBot.Logic.Common
             new KeyValuePair<TranslationString, string>(Common.TranslationString.GoogleTwoFactorAuth, "As you have Google Two Factor Auth enabled, you will need to insert an App Specific Password into the auth.json"),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.GoogleTwoFactorAuthExplanation, "Opening Google App-Passwords. Please make a new App Password (use Other as Device)"),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.GoogleError, "Make sure you have entered the right Email & Password."),
-            new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsGoogle, "You need to fill out GoogleUsername and GooglePassword in auth.json!"),
-            new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsPtc, "You need to fill out PtcUsername and PtcPassword in auth.json!"),
+            new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsGoogle, "You need to fill out Username and Password in auth.json!"),
+            new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsPtc, "You need to fill out Username and Password in auth.json!"),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.SnipeScan, "[Sniper] Scanning for Snipeable Pokemon at {0}..."),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.NoPokemonToSnipe, "[Sniper] No Pokemon found to snipe!"),
         };

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -426,8 +426,10 @@ namespace PoGo.NecroBot.CLI
         }
 
 
-        public string Username => _settings.Auth.Username;
-        public string Password => _settings.Auth.Password;
+        public string PtcUsername => _settings.Auth.Username;
+        public string PtcPassword => _settings.Auth.Password;
+        public string GoogleUsername => _settings.Auth.Username;
+        public string GooglePassword => _settings.Auth.Password;
 
         public string GoogleRefreshToken
         {
@@ -491,7 +493,7 @@ namespace PoGo.NecroBot.CLI
             }
         }
 
-        string ISettings.Username
+        string ISettings.PtcUsername
         {
             get
             {
@@ -503,7 +505,31 @@ namespace PoGo.NecroBot.CLI
                 _settings.Auth.Username = value;
             }
         }
-        string ISettings.Password
+        string ISettings.PtcPassword
+        {
+            get
+            {
+                return _settings.Auth.Password;
+            }
+
+            set
+            {
+                _settings.Auth.Password = value;
+            }
+        }
+        string ISettings.GoogleUsername
+        {
+            get
+            {
+                return _settings.Auth.Username;
+            }
+
+            set
+            {
+                _settings.Auth.Username = value;
+            }
+        }
+        string ISettings.GooglePassword
         {
             get
             {

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -24,10 +24,8 @@ namespace PoGo.NecroBot.CLI
         private string _filePath;
 
         public string GoogleRefreshToken;
-        public string PtcUsername;
-        public string PtcPassword;
-        public string GoogleUsername;
-        public string GooglePassword;
+        public string Username;
+        public string Password;
 
         public void Load(string path)
         {
@@ -52,14 +50,10 @@ namespace PoGo.NecroBot.CLI
             }
             catch(Newtonsoft.Json.JsonReaderException exception)
             {
-                if (exception.Message.Contains("Unexpected character") && exception.Message.Contains("PtcUsername"))
-                    Logger.Write("JSON Exception: You need to properly configure your PtcUsername using quotations.", LogLevel.Error);
-                else if (exception.Message.Contains("Unexpected character") && exception.Message.Contains("PtcPassword"))
-                    Logger.Write("JSON Exception: You need to properly configure your PtcPassword using quotations.", LogLevel.Error);
-                else if (exception.Message.Contains("Unexpected character") && exception.Message.Contains("GoogleUsername"))
-                    Logger.Write("JSON Exception: You need to properly configure your GoogleUsername using quotations.", LogLevel.Error);
-                else if (exception.Message.Contains("Unexpected character") && exception.Message.Contains("GooglePassword"))
-                    Logger.Write("JSON Exception: You need to properly configure your GooglePassword using quotations.", LogLevel.Error);
+                if (exception.Message.Contains("Unexpected character") && exception.Message.Contains("Username"))
+                    Logger.Write("JSON Exception: You need to properly configure your Username using quotations.", LogLevel.Error);
+                else if (exception.Message.Contains("Unexpected character") && exception.Message.Contains("Password"))
+                    Logger.Write("JSON Exception: You need to properly configure your Password using quotations.", LogLevel.Error);
                 else
                     Logger.Write("JSON Exception: " + exception.Message, LogLevel.Error);
             }
@@ -432,8 +426,8 @@ namespace PoGo.NecroBot.CLI
         }
 
 
-        public string GoogleUsername => _settings.Auth.GoogleUsername;
-        public string GooglePassword => _settings.Auth.GooglePassword;
+        public string Username => _settings.Auth.Username;
+        public string Password => _settings.Auth.Password;
 
         public string GoogleRefreshToken
         {
@@ -497,54 +491,28 @@ namespace PoGo.NecroBot.CLI
             }
         }
 
-        string ISettings.PtcPassword
+        string ISettings.Username
         {
             get
             {
-                return _settings.Auth.PtcPassword;
+                return _settings.Auth.Username;
             }
 
             set
             {
-                _settings.Auth.PtcPassword = value;
+                _settings.Auth.Username = value;
             }
         }
-
-        string ISettings.PtcUsername
+        string ISettings.Password
         {
             get
             {
-                return _settings.Auth.PtcUsername;
+                return _settings.Auth.Password;
             }
 
             set
             {
-                _settings.Auth.PtcUsername = value;
-            }
-        }
-
-        string ISettings.GoogleUsername
-        {
-            get
-            {
-                return _settings.Auth.GoogleUsername;
-            }
-
-            set
-            {
-                _settings.Auth.GoogleUsername = value;
-            }
-        }
-        string ISettings.GooglePassword
-        {
-            get
-            {
-                return _settings.Auth.GooglePassword;
-            }
-
-            set
-            {
-                _settings.Auth.GooglePassword = value;
+                _settings.Auth.Password = value;
             }
         }
     }

--- a/PoGo.NecroBot.Logic/State/LoginState.cs
+++ b/PoGo.NecroBot.Logic/State/LoginState.cs
@@ -94,22 +94,13 @@ namespace PoGo.NecroBot.Logic.State
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (session.Settings.AuthType == AuthType.Google &&
-                            (session.Settings.Username == null || session.Settings.Password == null))
+            if (
+                (session.Settings.AuthType == AuthType.Google || session.Settings.AuthType == AuthType.Ptc) &&
+                (session.Settings.Username == null || session.Settings.Password == null) )
             {
                 session.EventDispatcher.Send(new ErrorEvent
                 {
-                    Message = session.Translation.GetTranslation(TranslationString.MissingCredentialsGoogle)
-                });
-                await Task.Delay(2000, cancellationToken);
-                Environment.Exit(0);
-            }
-            else if (session.Settings.AuthType == AuthType.Ptc &&
-                     (session.Settings.Username == null || session.Settings.Password == null))
-            {
-                session.EventDispatcher.Send(new ErrorEvent
-                {
-                    Message = session.Translation.GetTranslation(TranslationString.MissingCredentialsPtc)
+                    Message = session.Translation.GetTranslation(TranslationString.MissingCredentials)
                 });
                 await Task.Delay(2000, cancellationToken);
                 Environment.Exit(0);

--- a/PoGo.NecroBot.Logic/State/LoginState.cs
+++ b/PoGo.NecroBot.Logic/State/LoginState.cs
@@ -32,7 +32,7 @@ namespace PoGo.NecroBot.Logic.State
                     case AuthType.Ptc:
                         try
                         {
-                            await session.Client.Login.DoPtcLogin(session.Settings.PtcUsername, session.Settings.PtcPassword);
+                            await session.Client.Login.DoPtcLogin(session.Settings.Username, session.Settings.Password);
                         }
                         catch (AggregateException ae)
                         {
@@ -40,7 +40,7 @@ namespace PoGo.NecroBot.Logic.State
                         }
                         break;
                     case AuthType.Google:
-                        await session.Client.Login.DoGoogleLogin(session.Settings.GoogleUsername, session.Settings.GooglePassword);
+                        await session.Client.Login.DoGoogleLogin(session.Settings.Username, session.Settings.Password);
                         break;
                     default:
                         session.EventDispatcher.Send(new ErrorEvent { Message = session.Translation.GetTranslation(Common.TranslationString.WrongAuthType) });
@@ -95,7 +95,7 @@ namespace PoGo.NecroBot.Logic.State
             cancellationToken.ThrowIfCancellationRequested();
 
             if (session.Settings.AuthType == AuthType.Google &&
-                            (session.Settings.GoogleUsername == null || session.Settings.GooglePassword == null))
+                            (session.Settings.Username == null || session.Settings.Password == null))
             {
                 session.EventDispatcher.Send(new ErrorEvent
                 {
@@ -105,7 +105,7 @@ namespace PoGo.NecroBot.Logic.State
                 Environment.Exit(0);
             }
             else if (session.Settings.AuthType == AuthType.Ptc &&
-                     (session.Settings.PtcUsername == null || session.Settings.PtcPassword == null))
+                     (session.Settings.Username == null || session.Settings.Password == null))
             {
                 session.EventDispatcher.Send(new ErrorEvent
                 {

--- a/PoGo.NecroBot.Logic/Tasks/Login.cs
+++ b/PoGo.NecroBot.Logic/Tasks/Login.cs
@@ -34,8 +34,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 {
                     try
                     {
-                        _session.Client.Login.DoPtcLogin(_session.Settings.PtcUsername, _session.Settings.PtcPassword)
-                            .Wait();
+                        _session.Client.Login.DoPtcLogin(_session.Settings.Username, _session.Settings.Password).Wait();
                     }
                     catch (AggregateException ae)
                     {
@@ -44,8 +43,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 }
                 else
                 {
-                    _session.Client.Login.DoGoogleLogin(_session.Settings.GoogleUsername,
-                        _session.Settings.GooglePassword).Wait();
+                    _session.Client.Login.DoGoogleLogin(_session.Settings.Username, _session.Settings.Password).Wait();
                 }
             }
             catch (PtcOfflineException)


### PR DESCRIPTION
Don't know why RocketAPI decided to make separate login config in a single config file now that we switched to user/pass for google as well. Really no need to be repeating prefixed fields if you already have a selector of AuthType in the config.