### PR TITLE
Min delay between Item Recycle & Min KM to walk for limited incubator

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -96,6 +96,8 @@ namespace PoGo.NecroBot.Logic
         bool UseSnipeLocationServer { get; }
         bool UseTransferIVForSnipe { get; }
         int MinDelayBetweenSnipes { get; }
+        int MinDelayBetweenRecycle { get; }
+        int minEggKmForLimitedIncubators { get; }
 
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -121,6 +121,8 @@ namespace PoGo.NecroBot.CLI
         public bool UseSnipeLocationServer = false;
         public bool UseTransferIVForSnipe = false;
         public int MinDelayBetweenSnipes = 20000;
+        public int MinDelayBetweenRecycle = 20000;
+        public int minEggKmForLimitedIncubators = 10;
 
         public List<KeyValuePair<ItemId, int>> ItemRecycleFilter = new List<KeyValuePair<ItemId, int>>
         {
@@ -530,5 +532,7 @@ namespace PoGo.NecroBot.CLI
         public bool UseSnipeLocationServer=> _settings.UseSnipeLocationServer;
         public bool UseTransferIVForSnipe => _settings.UseTransferIVForSnipe;
         public int MinDelayBetweenSnipes => _settings.MinDelayBetweenSnipes;
+        public int MinDelayBetweenRecycle => _settings.MinDelayBetweenRecycle;
+        public int minEggKmForLimitedIncubators => _settings.minEggKmForLimitedIncubators;
     }
 }

--- a/PoGo.NecroBot.Logic/State/StateMachine.cs
+++ b/PoGo.NecroBot.Logic/State/StateMachine.cs
@@ -37,6 +37,7 @@ namespace PoGo.NecroBot.Logic.State
                 }
                 catch (InvalidResponseException)
                 {
+
                     session.EventDispatcher.Send(new ErrorEvent { Message = "The PokemonGo servers are having a bad time, chill." });
                 }
                 catch (OperationCanceledException)

--- a/PoGo.NecroBot.Logic/State/StateMachine.cs
+++ b/PoGo.NecroBot.Logic/State/StateMachine.cs
@@ -37,7 +37,6 @@ namespace PoGo.NecroBot.Logic.State
                 }
                 catch (InvalidResponseException)
                 {
-
                     session.EventDispatcher.Send(new ErrorEvent { Message = "The PokemonGo servers are having a bad time, chill." });
                 }
                 catch (OperationCanceledException)

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -1,5 +1,5 @@
 ﻿#region using directives
-
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using PoGo.NecroBot.Logic.Event;
@@ -12,8 +12,11 @@ namespace PoGo.NecroBot.Logic.Tasks
 {
     public class RecycleItemsTask
     {
+        private static DateTime lastRecycle = DateTime.Now;
         public static async Task Execute(ISession session, CancellationToken cancellationToken)
         {
+            if (lastRecycle.AddMilliseconds(session.LogicSettings.MinDelayBetweenRecycle) > DateTime.Now)
+                return;
             cancellationToken.ThrowIfCancellationRequested();
 
             var items = await session.Inventory.GetItemsToRecycle(session.Settings);
@@ -28,7 +31,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
             }
-
+            lastRecycle = DateTime.Now;
             await session.Inventory.RefreshCachedInventory();
         }
     }

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -1,4 +1,5 @@
 ﻿#region using directives
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,6 +32,7 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
             }
+
             lastRecycle = DateTime.Now;
             await session.Inventory.RefreshCachedInventory();
         }

--- a/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
@@ -75,6 +75,10 @@ namespace PoGo.NecroBot.Logic.Tasks
                     if (egg == null)
                         continue;
 
+                    //avoid using 5 or 2 km eggs with limited incubator
+                    if (egg.EggKmWalkedTarget < session.LogicSettings.minEggKmForLimitedIncubators && incubator.ItemId != ItemId.ItemIncubatorBasicUnlimited)
+                        continue;
+
                     var response = await session.Client.Inventory.UseItemEggIncubator(incubator.Id, egg.Id);
                     unusedEggs.Remove(egg);
 

--- a/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/UseIncubatorsTask.cs
@@ -75,7 +75,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     if (egg == null)
                         continue;
 
-                    //avoid using 5 or 2 km eggs with limited incubator
+                    //avoid using 2/5 km eggs with limited incubator
                     if (egg.EggKmWalkedTarget < session.LogicSettings.minEggKmForLimitedIncubators && incubator.ItemId != ItemId.ItemIncubatorBasicUnlimited)
                         continue;
 


### PR DESCRIPTION
I kept getting recycles after almost every pokestop so I added a minimum delay to avoid waste of time. Recycling bigger stacks saves time.

I also was seeing 2km eggs being put into my limited use incubators so I put an according line to prevent the bot from using small eggs. Can be set in settings (2 = all, 5 = skip 2km, 10= skip 2 & 5 km and 11+ = don't use limited use incubators)

This is my first code change so please check and constructive feedback is always welcome.