### PR TITLE
Enhanced pokeball-management for sniping

### DIFF
--- a/PoGo.NecroBot.Logic/Common/Translations.cs
+++ b/PoGo.NecroBot.Logic/Common/Translations.cs
@@ -116,6 +116,7 @@ namespace PoGo.NecroBot.Logic.Common
         MissingCredentialsPtc,
         SnipeScan,
         NoPokemonToSnipe,
+        NotEnoughPokeballsToSnipe,
     }
 
     public class Translation : ITranslation
@@ -224,6 +225,7 @@ namespace PoGo.NecroBot.Logic.Common
             new KeyValuePair<TranslationString, string>(Common.TranslationString.MissingCredentialsPtc, "You need to fill out PtcUsername and PtcPassword in auth.json!"),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.SnipeScan, "[Sniper] Scanning for Snipeable Pokemon at {0}..."),
             new KeyValuePair<TranslationString, string>(Common.TranslationString.NoPokemonToSnipe, "[Sniper] No Pokemon found to snipe!"),
+            new KeyValuePair<TranslationString, string>(Common.TranslationString.NotEnoughPokeballsToSnipe, "Not enough Pokeballs to start sniping! ({0}/{1})"),
         };
 
         public string GetTranslation(TranslationString translationString, params object[] data)

--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -92,6 +92,7 @@ namespace PoGo.NecroBot.Logic
         string GeneralConfigPath { get; }
         bool SnipeAtPokestops { get; }
         int MinPokeballsToSnipe { get; }
+        int MinPokeballsWhileSnipe { get; }
         string SnipeLocationServer { get; }
         int SnipeLocationServerPort { get; }
         bool UseSnipeLocationServer { get; }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -133,6 +133,7 @@ namespace PoGo.NecroBot.CLI
         public bool StartupWelcomeDelay = true;
         public bool SnipeAtPokestops = false;
         public int MinPokeballsToSnipe = 20;
+        public int MinPokeballsWhileSnipe = 0;
         public string SnipeLocationServer = "localhost";
         public int SnipeLocationServerPort = 16969;
         public bool UseSnipeLocationServer = false;
@@ -595,6 +596,7 @@ namespace PoGo.NecroBot.CLI
         public bool StartupWelcomeDelay => _settings.StartupWelcomeDelay;
         public bool SnipeAtPokestops => _settings.SnipeAtPokestops;
         public int MinPokeballsToSnipe => _settings.MinPokeballsToSnipe;
+        public int MinPokeballsWhileSnipe => _settings.MinPokeballsWhileSnipe;
         public SnipeSettings PokemonToSnipe => _settings.PokemonToSnipe;
         public string SnipeLocationServer => _settings.SnipeLocationServer;
         public int SnipeLocationServerPort => _settings.SnipeLocationServerPort;

--- a/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/SnipePokemonTask.cs
@@ -241,8 +241,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                         }
                     }
                 }
-                else
-
+                else if (await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsToSnipe, session, cancellationToken))
+                {
                     foreach (var location in session.LogicSettings.PokemonToSnipe.Locations)
                     {
                         session.EventDispatcher.Send(new SnipeScanEvent() { Bounds = location });
@@ -264,12 +264,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                             lastSnipe = DateTime.Now;
                             foreach (var pokemonLocation in locationsToSnipe)
                             {
-                                var pokeBallsCount = await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemPokeBall);
-                                var greatBallsCount = await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemGreatBall);
-                                var ultraBallsCount = await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemUltraBall);
-                                var masterBallsCount = await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemMasterBall);
-
-                                if (pokeBallsCount + greatBallsCount + ultraBallsCount + masterBallsCount < session.LogicSettings.MinPokeballsToSnipe)
+                                if (!await CheckPokeballsToSnipe(session.LogicSettings.MinPokeballsWhileSnipe + 1, session, cancellationToken))
                                     return;
 
                                 locsVisited.Add(pokemonLocation);
@@ -285,6 +280,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                             });
                         }
                     }
+                }
             }
 
         }
@@ -316,6 +312,25 @@ namespace PoGo.NecroBot.Logic.Tasks
                 };
             }
             return scanResult;
+        }
+
+        public static async Task<bool> CheckPokeballsToSnipe(int minPokeballs, ISession session, CancellationToken cancellationToken)
+        {
+            var pokeBallsCount = await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemPokeBall);
+            pokeBallsCount += await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemGreatBall);
+            pokeBallsCount += await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemUltraBall);
+            pokeBallsCount += await session.Inventory.GetItemAmountByType(POGOProtos.Inventory.Item.ItemId.ItemMasterBall);
+
+            if (pokeBallsCount < minPokeballs)
+            {
+                session.EventDispatcher.Send(new NoticeEvent()
+                {
+                    Message = session.Translation.GetTranslation(Common.TranslationString.NotEnoughPokeballsToSnipe, pokeBallsCount, minPokeballs)
+                });
+                return false;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
This replaces "Fixed MinPokeballsToSnipe".

At the moment the bot stops sniping if he falls below the MinPokeballsToSnipe value. For example with "MinPokeballsToSnipe" = 100 he will stop sniping if he has 99 pokeballs left.

I don't think that was intended. With the fix he will snipe until he has MinPokeballsWhileSnipe pokeballs left and only start sniping if he has at least MinPokeballsToSnipe pokeballs.