### PR TITLE
MaxPokeballsPerPokemon

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -97,6 +97,7 @@ namespace PoGo.NecroBot.Logic
         bool SnipeAtPokestops { get; }
         int MinPokeballsToSnipe { get; }
         int MinPokeballsWhileSnipe { get; }
+        int MaxPokeballsPerPokemon { get; }
         string SnipeLocationServer { get; }
         int SnipeLocationServerPort { get; }
         bool UseSnipeLocationServer { get; }

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -138,6 +138,7 @@ namespace PoGo.NecroBot.CLI
         public bool SnipeAtPokestops = false;
         public int MinPokeballsToSnipe = 20;
         public int MinPokeballsWhileSnipe = 0;
+        public int MaxPokeballsPerPokemon = 6;
         public string SnipeLocationServer = "localhost";
         public int SnipeLocationServerPort = 16969;
         public bool UseSnipeLocationServer = false;
@@ -621,6 +622,8 @@ namespace PoGo.NecroBot.CLI
         public bool SnipeAtPokestops => _settings.SnipeAtPokestops;
         public int MinPokeballsToSnipe => _settings.MinPokeballsToSnipe;
         public int MinPokeballsWhileSnipe => _settings.MinPokeballsWhileSnipe;
+        public int MaxPokeballsPerPokemon => _settings.MaxPokeballsPerPokemon;
+
         public SnipeSettings PokemonToSnipe => _settings.PokemonToSnipe;
         public string SnipeLocationServer => _settings.SnipeLocationServer;
         public int SnipeLocationServerPort => _settings.SnipeLocationServerPort;

--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -25,6 +25,10 @@ namespace PoGo.NecroBot.Logic.Tasks
             var attemptCounter = 1;
             do
             {
+                if (session.LogicSettings.MaxPokeballsPerPokemon > 0 &&
+                    attemptCounter > session.LogicSettings.MaxPokeballsPerPokemon)
+                    break;
+
                 float probability = encounter?.CaptureProbability?.CaptureProbability_[0];
 
                 var pokeball = await GetBestBall(session, encounter, probability);


### PR DESCRIPTION
Set a max amount of pokeballs/retrys that can be used per pokemon. 0 for
no limit.