### PR TITLE
TotalAmountOfPokebalsToKeep lowered to 100

### DIFF
--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -146,7 +146,7 @@ namespace PoGo.NecroBot.CLI
         public bool UseTransferIVForSnipe = false;
         public bool SnipeIgnoreUnknownIV = false;
         public int MinDelayBetweenSnipes = 20000;
-        public int TotalAmountOfPokebalsToKeep = 120;
+        public int TotalAmountOfPokebalsToKeep = 100;
         public int TotalAmountOfPotionsToKeep = 80;
         public int TotalAmountOfRevivesToKeep = 60;
 


### PR DESCRIPTION
• if account has stacked incenses/lucky eggs/lures since level1 would exceed 350 items limit and trigger the full inventory continuosly