### PR TITLE
Added config option: "KeepEvolvablesOnlyIfOnEvolutionList"

### DIFF
--- a/PoGo.NecroBot.Logic/ILogicSettings.cs
+++ b/PoGo.NecroBot.Logic/ILogicSettings.cs
@@ -67,6 +67,7 @@ namespace PoGo.NecroBot.Logic
         double WalkingSpeedInKilometerPerHour { get; }
         bool EvolveAllPokemonWithEnoughCandy { get; }
         bool KeepPokemonsThatCanEvolve { get; }
+        bool KeepEvolvablesOnlyIfOnEvolutionList { get; }
         bool TransferDuplicatePokemon { get; }
         bool UseEggIncubators { get; }
         int UseGreatBallAboveCp { get; }

--- a/PoGo.NecroBot.Logic/Inventory.cs
+++ b/PoGo.NecroBot.Logic/Inventory.cs
@@ -112,8 +112,16 @@ namespace PoGo.NecroBot.Logic
                     if (settings.CandyToEvolve > 0)
                     {
                         var amountPossible = familyCandy.Candy_/settings.CandyToEvolve;
-                        if (amountPossible > amountToSkip)
-                            amountToSkip = amountPossible;
+                        if (_logicSettings.KeepEvolvablesOnlyIfOnEvolutionList)
+                        {
+                            if (amountPossible > amountToSkip && _logicSettings.PokemonsToEvolve.Contains(pokemon.Key))
+                                amountToSkip = amountPossible;
+                        }
+                        else
+                        {
+                            if (amountPossible > amountToSkip)
+                                amountToSkip = amountPossible;
+                        }
                     }
 
                     if (prioritizeIVoverCp)

--- a/PoGo.NecroBot.Logic/Properties/AssemblyInfo.cs
+++ b/PoGo.NecroBot.Logic/Properties/AssemblyInfo.cs
@@ -39,5 +39,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.3.3")]
+[assembly: AssemblyVersion("0.4.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -147,6 +147,7 @@ namespace PoGo.NecroBot.Logic
         public int KeepMinDuplicatePokemon = 1;
         public float KeepMinIvPercentage = 90;
         public bool KeepPokemonsThatCanEvolve = false;
+        public bool KeepEvolvablesOnlyIfOnEvolutionList = false;
         public string LevelUpByCPorIv = "iv";
         public int MaxPokeballsPerPokemon = 6;
         public int MaxSpawnLocationOffset = 10;
@@ -587,6 +588,7 @@ namespace PoGo.NecroBot.Logic
         public double WalkingSpeedInKilometerPerHour => _settings.WalkingSpeedInKilometerPerHour;
         public bool EvolveAllPokemonWithEnoughCandy => _settings.EvolveAllPokemonWithEnoughCandy;
         public bool KeepPokemonsThatCanEvolve => _settings.KeepPokemonsThatCanEvolve;
+        public bool KeepEvolvablesOnlyIfOnEvolutionList => _settings.KeepEvolvablesOnlyIfOnEvolutionList;
         public bool TransferDuplicatePokemon => _settings.TransferDuplicatePokemon;
         public bool UseEggIncubators => _settings.UseEggIncubators;
         public int UseGreatBallAboveCp => _settings.UseGreatBallAboveCp;


### PR DESCRIPTION
Added config option: "KeepEvolvablesOnlyIfOnEvolutionList"
Defaults to false.
If "KeepPokemonsThatCanEvolve" is true, and
"KeepEvolvablesOnlyIfOnEvolutionList" is also true, the bot will NOT
keep pokemon it has enough candy to evolve, unless they are on the
"PokemonsToEvolve" list.