### PR TITLE
Impltement optimized recycling

### DIFF
--- a/PoGo.NecroBot.Logic/Properties/AssemblyInfo.cs
+++ b/PoGo.NecroBot.Logic/Properties/AssemblyInfo.cs
@@ -39,5 +39,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.3.3")]
+[assembly: AssemblyVersion("0.4.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/PoGo.NecroBot.Logic/Tasks/DisplayPokemonStatsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/DisplayPokemonStatsTask.cs
@@ -77,7 +77,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 var tokens = dgdfs.Split(new[] {"id"}, StringSplitOptions.None);
                 var splitone = tokens[1].Split('"');
                 var iv = session.Inventory.GetPerfect(pokemon.Item1);
-                if (iv > session.LogicSettings.UpgradePokemonIvMinimum)
+                if (iv >= session.LogicSettings.UpgradePokemonIvMinimum)
                 {
                     PokemonId.Add(ulong.Parse(splitone[2]));
                 }
@@ -90,7 +90,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                 var tokensSplit = tokens[1].Split(new[] {"cp"}, StringSplitOptions.None);
                 var tokenSplitAgain = tokensSplit[1].Split(' ');
                 var tokenSplitAgain2 = tokenSplitAgain[1].Split(',');
-                if (float.Parse(tokenSplitAgain2[0]) > session.LogicSettings.UpgradePokemonCpMinimum)
+                if (float.Parse(tokenSplitAgain2[0]) >= session.LogicSettings.UpgradePokemonCpMinimum)
                 {
                     PokemonIdcp.Add(ulong.Parse(splitone[2]));
                 }

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using PoGo.NecroBot.Logic.Event;
 using PoGo.NecroBot.Logic.State;
 using PoGo.NecroBot.Logic.Utils;
+using POGOProtos.Inventory.Item;
 
 #endregion
 
@@ -28,6 +29,89 @@ namespace PoGo.NecroBot.Logic.Tasks
 
                 DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
             }
+
+            var pokeBallsCount = await session.Inventory.GetItemAmountByType(ItemId.ItemPokeBall);
+            var greatBallsCount = await session.Inventory.GetItemAmountByType(ItemId.ItemGreatBall);
+            var ultraBallsCount = await session.Inventory.GetItemAmountByType(ItemId.ItemUltraBall);
+            var masterBallsCount = await session.Inventory.GetItemAmountByType(ItemId.ItemMasterBall);
+
+            int pokeBallsToRecycle = 0;
+            int greatBallsToRecycle = 0;
+            int ultraBallsToRecycle = 0;
+            int masterBallsToRecycle = 0;
+
+            int totalBallsCount = pokeBallsCount + greatBallsCount + ultraBallsCount + masterBallsCount;
+            if(totalBallsCount>session.LogicSettings.TotalAmountOfPokebalsToKeep)
+            {
+                int diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokebalsToKeep;
+                if (diff > 0)
+                {
+                    int pokeBallsToKeep = pokeBallsCount - diff;
+                    if (pokeBallsToKeep < 0)
+                    {
+                        pokeBallsToKeep = 0;
+                    }
+                    pokeBallsToRecycle = pokeBallsCount - pokeBallsToKeep;
+                    diff -= pokeBallsToRecycle;
+
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await session.Client.Inventory.RecycleItem(ItemId.ItemPokeBall, pokeBallsToRecycle);
+                    session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemPokeBall, Count = pokeBallsToRecycle });
+                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                }
+
+                if (diff>0)
+                {
+                    int greatBallsToKeep = greatBallsCount - diff;
+                    if (greatBallsToKeep < 0)
+                    {
+                        greatBallsToKeep = 0;
+                    }
+                    greatBallsToRecycle = greatBallsCount - greatBallsToKeep;
+                    diff -= greatBallsToRecycle;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await session.Client.Inventory.RecycleItem(ItemId.ItemGreatBall, greatBallsToRecycle);
+                    session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemGreatBall, Count = greatBallsToRecycle });
+                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                }
+
+                // Don't Recycle Ultra Balls
+                /*
+                if (diff > 0)
+                {
+                    int ultraBallsToKeep = ultraBallsCount - diff;
+                    if (ultraBallsToKeep < 0)
+                    {
+                        ultraBallsToKeep = 0;
+                    }
+                    ultraBallsToRecycle = ultraBallsCount - ultraBallsToKeep;
+                    diff -= ultraBallsToRecycle;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await session.Client.Inventory.RecycleItem(ItemId.ItemUltraBall, ultraBallsToRecycle);
+                    session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemUltraBall, Count = ultraBallsToRecycle });
+                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                }
+                */
+
+                // No Master Balls in Game, so far
+                /*
+                if (diff > 0)
+                {
+                    int masterBallsToKeep = masterBallsCount - diff;
+                    if (masterBallsToKeep < 0)
+                    {
+                        masterBallsToKeep = 0;
+                    }
+                    masterBallsToRecycle = masterBallsCount - masterBallsToKeep;
+                    diff -= masterBallsToRecycle;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await session.Client.Inventory.RecycleItem(ItemId.ItemMasterBall, masterBallsToRecycle);
+                    session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemMasterBall, Count = masterBallsToRecycle });
+                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                }
+                */   
+            }
+
 
             await session.Inventory.RefreshCachedInventory();
         }

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -30,6 +30,16 @@ namespace PoGo.NecroBot.Logic.Tasks
                 DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
             }
 
+            if (session.LogicSettings.TotalAmountOfPokebalsToKeep != 0)
+            {
+                await OptimizedRecycleBalls(session, cancellationToken);
+            }
+
+            await session.Inventory.RefreshCachedInventory();
+        }
+
+        private static async Task OptimizedRecycleBalls(ISession session, CancellationToken cancellationToken)
+        {
             var pokeBallsCount = await session.Inventory.GetItemAmountByType(ItemId.ItemPokeBall);
             var greatBallsCount = await session.Inventory.GetItemAmountByType(ItemId.ItemGreatBall);
             var ultraBallsCount = await session.Inventory.GetItemAmountByType(ItemId.ItemUltraBall);
@@ -41,7 +51,7 @@ namespace PoGo.NecroBot.Logic.Tasks
             int masterBallsToRecycle = 0;
 
             int totalBallsCount = pokeBallsCount + greatBallsCount + ultraBallsCount + masterBallsCount;
-            if(totalBallsCount>session.LogicSettings.TotalAmountOfPokebalsToKeep)
+            if (totalBallsCount > session.LogicSettings.TotalAmountOfPokebalsToKeep)
             {
                 int diff = totalBallsCount - session.LogicSettings.TotalAmountOfPokebalsToKeep;
                 if (diff > 0)
@@ -60,7 +70,7 @@ namespace PoGo.NecroBot.Logic.Tasks
                     DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
                 }
 
-                if (diff>0)
+                if (diff > 0)
                 {
                     int greatBallsToKeep = greatBallsCount - diff;
                     if (greatBallsToKeep < 0)
@@ -109,11 +119,8 @@ namespace PoGo.NecroBot.Logic.Tasks
                     session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemMasterBall, Count = masterBallsToRecycle });
                     DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
                 }
-                */   
+                */
             }
-
-
-            await session.Inventory.RefreshCachedInventory();
         }
     }
 }

--- a/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/RecycleItemsTask.cs
@@ -35,6 +35,16 @@ namespace PoGo.NecroBot.Logic.Tasks
                 await OptimizedRecycleBalls(session, cancellationToken);
             }
 
+            if (session.LogicSettings.TotalAmountOfPotionsToKeep != 0)
+            {
+                await OptimizedRecyclePotions(session, cancellationToken);
+            }
+
+            if (session.LogicSettings.TotalAmountOfRevivesToKeep != 0)
+            {
+                await OptimizedRecycleRevives(session, cancellationToken);
+            }
+
             await session.Inventory.RefreshCachedInventory();
         }
 
@@ -62,12 +72,15 @@ namespace PoGo.NecroBot.Logic.Tasks
                         pokeBallsToKeep = 0;
                     }
                     pokeBallsToRecycle = pokeBallsCount - pokeBallsToKeep;
-                    diff -= pokeBallsToRecycle;
-
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await session.Client.Inventory.RecycleItem(ItemId.ItemPokeBall, pokeBallsToRecycle);
-                    session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemPokeBall, Count = pokeBallsToRecycle });
-                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    
+                    if (pokeBallsToRecycle != 0)
+                    {
+                        diff -= pokeBallsToRecycle;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await session.Client.Inventory.RecycleItem(ItemId.ItemPokeBall, pokeBallsToRecycle);
+                        session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemPokeBall, Count = pokeBallsToRecycle });
+                        DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    }
                 }
 
                 if (diff > 0)
@@ -78,11 +91,15 @@ namespace PoGo.NecroBot.Logic.Tasks
                         greatBallsToKeep = 0;
                     }
                     greatBallsToRecycle = greatBallsCount - greatBallsToKeep;
-                    diff -= greatBallsToRecycle;
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await session.Client.Inventory.RecycleItem(ItemId.ItemGreatBall, greatBallsToRecycle);
-                    session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemGreatBall, Count = greatBallsToRecycle });
-                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    
+                    if (greatBallsToRecycle != 0)
+                    {
+                        diff -= greatBallsToRecycle;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await session.Client.Inventory.RecycleItem(ItemId.ItemGreatBall, greatBallsToRecycle);
+                        session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemGreatBall, Count = greatBallsToRecycle });
+                        DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    }
                 }
 
                 // Don't Recycle Ultra Balls
@@ -95,11 +112,15 @@ namespace PoGo.NecroBot.Logic.Tasks
                         ultraBallsToKeep = 0;
                     }
                     ultraBallsToRecycle = ultraBallsCount - ultraBallsToKeep;
-                    diff -= ultraBallsToRecycle;
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await session.Client.Inventory.RecycleItem(ItemId.ItemUltraBall, ultraBallsToRecycle);
-                    session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemUltraBall, Count = ultraBallsToRecycle });
-                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+
+                    if (ultraBallsToRecycle != 0)
+                    {
+                        diff -= ultraBallsToRecycle;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await session.Client.Inventory.RecycleItem(ItemId.ItemUltraBall, ultraBallsToRecycle);
+                        session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemUltraBall, Count = ultraBallsToRecycle });
+                        DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    }
                 }
                 */
 
@@ -113,13 +134,163 @@ namespace PoGo.NecroBot.Logic.Tasks
                         masterBallsToKeep = 0;
                     }
                     masterBallsToRecycle = masterBallsCount - masterBallsToKeep;
-                    diff -= masterBallsToRecycle;
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await session.Client.Inventory.RecycleItem(ItemId.ItemMasterBall, masterBallsToRecycle);
-                    session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemMasterBall, Count = masterBallsToRecycle });
-                    DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+
+                    if (masterBallsToRecycle != 0)
+                    {
+                        diff -= masterBallsToRecycle;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await session.Client.Inventory.RecycleItem(ItemId.ItemMasterBall, masterBallsToRecycle);
+                        session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemMasterBall, Count = masterBallsToRecycle });
+                        DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    }
                 }
                 */
+            }
+        }
+
+        private static async Task OptimizedRecyclePotions(ISession session, CancellationToken cancellationToken)
+        {
+            var potionCount = await session.Inventory.GetItemAmountByType(ItemId.ItemPotion);
+            var superPotionCount = await session.Inventory.GetItemAmountByType(ItemId.ItemSuperPotion);
+            var hyperPotionsCount = await session.Inventory.GetItemAmountByType(ItemId.ItemHyperPotion);
+            var maxPotionCount = await session.Inventory.GetItemAmountByType(ItemId.ItemMaxPotion);
+
+            int potionsToRecycle = 0;
+            int superPotionsToRecycle = 0;
+            int hyperPotionsToRecycle = 0;
+            int maxPotionsToRecycle = 0;
+
+            int totalPotionsCount = potionCount + superPotionCount + hyperPotionsCount + maxPotionCount;
+            if (totalPotionsCount > session.LogicSettings.TotalAmountOfPotionsToKeep)
+            {
+                int diff = totalPotionsCount - session.LogicSettings.TotalAmountOfPotionsToKeep;
+                if (diff > 0)
+                {
+                    int potionsToKeep = potionCount - diff;
+                    if (potionsToKeep < 0)
+                    {
+                        potionsToKeep = 0;
+                    }
+                    potionsToRecycle = potionCount - potionsToKeep;
+
+                    if (potionsToRecycle != 0)
+                    {
+                        diff -= potionsToRecycle;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await session.Client.Inventory.RecycleItem(ItemId.ItemPotion, potionsToRecycle);
+                        session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemPotion, Count = potionsToRecycle });
+                        DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    }
+                }
+
+                if (diff > 0)
+                {
+                    int superPotionsToKeep = superPotionCount - diff;
+                    if (superPotionsToKeep < 0)
+                    {
+                        superPotionsToKeep = 0;
+                    }
+                    superPotionsToRecycle = superPotionCount - superPotionsToKeep;
+
+                    if (superPotionsToRecycle != 0)
+                    {
+                        diff -= superPotionsToRecycle;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await session.Client.Inventory.RecycleItem(ItemId.ItemSuperPotion, superPotionsToRecycle);
+                        session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemSuperPotion, Count = superPotionsToRecycle });
+                        DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    }
+                }
+
+                if (diff > 0)
+                {
+                    int hyperPotionsToKeep = hyperPotionsCount - diff;
+                    if (hyperPotionsToKeep < 0)
+                    {
+                        hyperPotionsToKeep = 0;
+                    }
+                    hyperPotionsToRecycle = hyperPotionsCount - hyperPotionsToKeep;
+
+                    if (hyperPotionsToRecycle != 0)
+                    {
+                        diff -= hyperPotionsToRecycle;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await session.Client.Inventory.RecycleItem(ItemId.ItemHyperPotion, hyperPotionsToRecycle);
+                        session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemHyperPotion, Count = hyperPotionsToRecycle });
+                        DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    }
+                }
+
+                if (diff > 0)
+                {
+                    int maxPotionsToKeep = maxPotionCount - diff;
+                    if (maxPotionsToKeep < 0)
+                    {
+                        maxPotionsToKeep = 0;
+                    }
+                    maxPotionsToRecycle = maxPotionCount - maxPotionsToKeep;
+
+                    if (maxPotionsToRecycle != 0)
+                    {
+                        diff -= maxPotionsToRecycle;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await session.Client.Inventory.RecycleItem(ItemId.ItemMaxPotion, maxPotionsToRecycle);
+                        session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemMaxPotion, Count = maxPotionsToRecycle });
+                        DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    }
+                }
+            }
+        }
+
+        private static async Task OptimizedRecycleRevives(ISession session, CancellationToken cancellationToken)
+        {
+            var reviveCount = await session.Inventory.GetItemAmountByType(ItemId.ItemRevive);
+            var maxReviveCount = await session.Inventory.GetItemAmountByType(ItemId.ItemMaxRevive);
+            
+            int revivesToRecycle = 0;
+            int maxRevivesToRecycle = 0;
+
+            int totalRevivesCount = reviveCount + maxReviveCount;
+            if (totalRevivesCount > session.LogicSettings.TotalAmountOfRevivesToKeep)
+            {
+                int diff = totalRevivesCount - session.LogicSettings.TotalAmountOfRevivesToKeep;
+                if (diff > 0)
+                {
+                    int revivesToKeep = reviveCount - diff;
+                    if (revivesToKeep < 0)
+                    {
+                        revivesToKeep = 0;
+                    }
+                    revivesToRecycle = reviveCount - revivesToKeep;
+
+                    if (revivesToRecycle != 0)
+                    {
+                        diff -= revivesToRecycle;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await session.Client.Inventory.RecycleItem(ItemId.ItemRevive, revivesToRecycle);
+                        session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemRevive, Count = revivesToRecycle });
+                        DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    }
+                }
+
+                if (diff > 0)
+                {
+                    int maxRevivesToKeep = maxReviveCount - diff;
+                    if (maxRevivesToKeep < 0)
+                    {
+                        maxRevivesToKeep = 0;
+                    }
+                    maxRevivesToRecycle = maxReviveCount - maxRevivesToKeep;
+
+                    if (maxRevivesToRecycle != 0)
+                    {
+                        diff -= maxRevivesToRecycle;
+                        cancellationToken.ThrowIfCancellationRequested();
+                        await session.Client.Inventory.RecycleItem(ItemId.ItemMaxRevive, maxRevivesToRecycle);
+                        session.EventDispatcher.Send(new ItemRecycledEvent { Id = ItemId.ItemMaxRevive, Count = maxRevivesToRecycle });
+                        DelayingUtils.Delay(session.LogicSettings.DelayBetweenPlayerActions, 500);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
If the amount of total balls currently hold is greater than
TotalAmountOfPokebalsToKeep, the Bot will recycle poke balls from low
level balls.

In Configs, TotalAmountOfPokebalsToKeep should be less than the sum of
all separate poke balls in ItemRecycleFilter.

Now optimized recycling of potions and revives also works in latest commit.