### PR TITLE
Fix custom pokeball

### DIFF
--- a/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
+++ b/PoGo.NecroBot.Logic/Tasks/CatchPokemonTask.cs
@@ -195,9 +195,6 @@ namespace PoGo.NecroBot.Logic.Tasks
             if (greatBallsCount > 0 && iV >= session.LogicSettings.KeepMinIvPercentage && probability < 0.50)
                 return ItemId.ItemGreatBall;
 
-            if (greatBallsCount > 0 && pokemonCp >= 300)
-                return ItemId.ItemGreatBall;
-
             if (pokeBallsCount > 0)
                 return ItemId.ItemPokeBall;
             if (greatBallsCount > 0)


### PR DESCRIPTION
Without these custom pokeball on capture will works.

Right now every pokémon with 300 cp or more will use a great (or better) ball, bypassing custom pokeball settings.