### PR TITLE
DumpPokemonStats fix

### DIFF
--- a/PoGo.NecroBot.Logic/State/InfoState.cs
+++ b/PoGo.NecroBot.Logic/State/InfoState.cs
@@ -13,10 +13,7 @@ namespace PoGo.NecroBot.Logic.State
         public async Task<IState> Execute(ISession session, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
-            if (session.LogicSettings.AmountOfPokemonToDisplayOnStart > 0)
-                await DisplayPokemonStatsTask.Execute(session);
-
+            await DisplayPokemonStatsTask.Execute(session);
             return new FarmState();
         }
     }


### PR DESCRIPTION
Will work even if   "AmountOfPokemonToDisplayOnStart": 0
Some people don't want to flood console with it if they can get full list from the dump.