### PR TITLE
fix/settings-duplicate-PokemonToSnipe

### DIFF
--- a/PoGo.NecroBot.Logic/Settings.cs
+++ b/PoGo.NecroBot.Logic/Settings.cs
@@ -386,7 +386,6 @@ namespace PoGo.NecroBot.Logic
                 PokemonId.Scyther,
                 PokemonId.Magmar,
                 PokemonId.Electabuzz,
-                PokemonId.Magmar,
                 PokemonId.Jynx,
                 PokemonId.Gyarados,
                 PokemonId.Lapras,


### PR DESCRIPTION
Removed duplicate magmar in PokemonToSnipe settings.